### PR TITLE
Fixing the deprecation calculation erros

### DIFF
--- a/model-repos/aixia2021/lxmert/src/lxrt/optimization.py
+++ b/model-repos/aixia2021/lxmert/src/lxrt/optimization.py
@@ -140,8 +140,8 @@ class BertAdam(Optimizer):
 
                 # Decay the first and second moment running average coefficient
                 # In-place operations to update the averages at the same time
-                next_m.mul_(beta1).add_(1 - beta1, grad)
-                next_v.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                next_m.mul_(beta1).add_(grad, alpha = 1 - beta1)
+                next_v.mul_(beta2).addcmul_(grad, grad, value = 1 - beta2)
                 update = next_m / (next_v.sqrt() + group['e'])
 
                 # Just adding the square of the weights to the loss function is *not*


### PR DESCRIPTION
The `add_` and `addcmul_` signatures were changed in the meantime. Fixing to fit the new version. 