### PR TITLE
Removing the size_average deprecation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,6 @@ dmypy.json
 model-repos/guesswhat/data/
 model-repos/guesswhat/out/
 model-repos/aixia2021/bin/
+model-repos/aixia2021/data/
+model-repos/aixia2021/logs/
 

--- a/model-repos/aixia2021/testing/test_lstm.py
+++ b/model-repos/aixia2021/testing/test_lstm.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
     guesser_loss_function = nn.CrossEntropyLoss()
 
     # For Decider
-    decider_cross_entropy = nn.CrossEntropyLoss(size_average=False)
+    decider_cross_entropy = nn.CrossEntropyLoss(reduction='sum')
 
     # For QGen.
     _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)

--- a/model-repos/aixia2021/train/SL/train_base.py
+++ b/model-repos/aixia2021/train/SL/train_base.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     guesser_loss_function = nn.CrossEntropyLoss()
 
     #For Decider
-    decider_cross_entropy = nn.CrossEntropyLoss(size_average=False)
+    decider_cross_entropy = nn.CrossEntropyLoss(reduction='sum')
 
     # For QGen.
     _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)

--- a/model-repos/aixia2021/train/SL/train_bert.py
+++ b/model-repos/aixia2021/train/SL/train_bert.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     guesser_loss_function = nn.CrossEntropyLoss()
 
     # For Decider
-    decider_cross_entropy = nn.CrossEntropyLoss(size_average=False)
+    decider_cross_entropy = nn.CrossEntropyLoss(reduction='sum')
 
     # For QGen.
     _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     guesser_loss_function = nn.CrossEntropyLoss()
 
     # For Decider
-    decider_cross_entropy = nn.CrossEntropyLoss(size_average=False)
+    decider_cross_entropy = nn.CrossEntropyLoss(reduction='sum')
 
     # For QGen.
     _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)

--- a/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     guesser_loss_function = nn.CrossEntropyLoss()
 
     # For Decider
-    decider_cross_entropy = nn.CrossEntropyLoss(size_average=False)
+    decider_cross_entropy = nn.CrossEntropyLoss(reduction='sum')
 
     # For QGen.
     _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)


### PR DESCRIPTION
In several files, the` size_average=False` in CrossEntropyLoss needed ot be replaced with reduction='sum'.