### PR TITLE
Fix the truncation warnings in RoBERTa

### DIFF
--- a/model-repos/aixia2021/models/BERTEnsemble.py
+++ b/model-repos/aixia2021/models/BERTEnsemble.py
@@ -60,7 +60,7 @@ def convert_sents_to_features_roberta(sents, max_seq_length, tokenizer):
         if not sent:
             sent = [""]
 
-        encodings = tokenizer.encode_plus(sent, add_special_tokens=True, max_length=max_seq_length)
+        encodings = tokenizer.encode_plus(sent, add_special_tokens=True, max_length=max_seq_length, truncation = True)
 
         input_ids = encodings["input_ids"]
         input_mask = encodings["attention_mask"]


### PR DESCRIPTION
When running BERT there is the error:
`Truncation was not explicitly activated but `max_length` is provided a specific value, please use `truncation=True` to explicitly truncate examples to max length. Defaulting to 'longest_first' truncation strategy. If you encode pairs of sequences (GLUE-style) with the tokenizer you can select this strategy more precisely by providing a specific strategy to `truncation`.`
This tiny PR fixes that. 