### PR TITLE
GPU speed-up 

### DIFF
--- a/model-repos/aixia2021/lxmert/src/lxrt/entry.py
+++ b/model-repos/aixia2021/lxmert/src/lxrt/entry.py
@@ -23,6 +23,8 @@ import torch.nn as nn
 from lxmert.src.lxrt.modeling import LXRTFeatureExtraction as VisualBertForLXRFeature, VISUAL_CONFIG
 from lxmert.src.lxrt.tokenization import BertTokenizer
 
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
 
 # from lxrt.tokenization import BertTokenizer
 # from lxrt.modeling import LXRTFeatureExtraction as VisualBertForLXRFeature, VISUAL_CONFIG
@@ -116,9 +118,9 @@ class LXRTEncoder(nn.Module):
         train_features = convert_sents_to_features(
             sents, self.max_seq_length, self.tokenizer)
 
-        input_ids = torch.tensor([f.input_ids for f in train_features], dtype=torch.long).cuda()
-        input_mask = torch.tensor([f.input_mask for f in train_features], dtype=torch.long).cuda()
-        segment_ids = torch.tensor([f.segment_ids for f in train_features], dtype=torch.long).cuda()
+        input_ids = torch.tensor([f.input_ids for f in train_features], dtype=torch.long, device=device)
+        input_mask = torch.tensor([f.input_mask for f in train_features], dtype=torch.long, device=device)
+        segment_ids = torch.tensor([f.segment_ids for f in train_features], dtype=torch.long, device=device)
 
         output = self.model(input_ids, segment_ids, input_mask,
                             visual_feats=feats,

--- a/model-repos/aixia2021/models/BERTEnsemble.py
+++ b/model-repos/aixia2021/models/BERTEnsemble.py
@@ -4,6 +4,8 @@ from transformers import RobertaTokenizer, RobertaModel
 
 from models.Guesser import Guesser
 
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
 
 class InputFeatures(object):
     """A single set of features of data."""
@@ -152,8 +154,8 @@ class BERTEnsemble(nn.Module):
 
         features = convert_sents_to_features_roberta(history_raw, self.max_seq_length, self.tokenizer)
 
-        input_ids = torch.tensor([f.input_ids for f in features], dtype=torch.long).cuda()
-        input_mask = torch.tensor([f.input_mask for f in features], dtype=torch.float).cuda()
+        input_ids = torch.tensor([f.input_ids for f in features], dtype=torch.long, device=device)
+        input_mask = torch.tensor([f.input_mask for f in features], dtype=torch.float, device=device)
         # segment_ids = torch.tensor([f.segment_ids for f in features], dtype=torch.long).cuda()
 
         # for cls:

--- a/model-repos/aixia2021/models/QGen.py
+++ b/model-repos/aixia2021/models/QGen.py
@@ -79,7 +79,7 @@ class QGenSeq2Seq(nn.Module):
         hidden = encoder_hidden.transpose(1, 0)
         proj_visual_features = self.ReLU(self.scale_visual_to(visual_features))
 
-        cell = (torch.zeros(self.qgen_args['num_layers'], batch_size, self.qgen_args['hidden_dim'])).cuda()
+        cell = (torch.zeros(self.qgen_args['num_layers'], batch_size, self.qgen_args['hidden_dim']), device=torch.device('cuda'))
 
         # copy visual features for each input token
         proj_visual_features_batch = proj_visual_features.repeat(1, self.qgen_args['max_tgt_length']).view(

--- a/model-repos/aixia2021/train/SL/train_base.py
+++ b/model-repos/aixia2021/train/SL/train_base.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
                 pin_memory=True if device.type == 'cuda' else False,
-                drop_last=False,
+                drop_last=True,
                 num_workers=0
             )
 

--- a/model-repos/aixia2021/train/SL/train_base.py
+++ b/model-repos/aixia2021/train/SL/train_base.py
@@ -21,8 +21,9 @@ from utils.datasets.SL.N2NResNetDataset import N2NResNetDataset
 from utils.eval import calculate_accuracy
 from utils.wrap_var import to_var
 
-# TODO Make this capitalised everywhere to inform it is a global variable
-use_cuda = torch.cuda.is_available()
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+multiple_gpus_available = torch.cuda.device_count() > 1
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -52,9 +53,9 @@ if __name__ == '__main__':
         with open(model_dir+'args.json', 'w') as f:
             json.dump(vars(args), f) # converting args.namespace to dict
 
-    float_tensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
+    float_tensor = torch.cuda.FloatTensor if device.type == 'cuda' else torch.FloatTensor
     torch.manual_seed(exp_config['seed'])
-    if use_cuda:
+    if device.type == 'cuda':
         torch.cuda.manual_seed_all(exp_config['seed'])
 
     # Init Model
@@ -64,17 +65,17 @@ if __name__ == '__main__':
         checkpoint = torch.load('bin/SL/ensemble_base2022_06_24_18_53/model_ensemble_ensemble_base_E_0')
         model.load_state_dict(checkpoint)
 
-    if use_cuda:
-        model.cuda()
+    if multiple_gpus_available:
         model = DataParallel(model)
+    model.to(device)
     print(model)
 
     if args.resnet:
         cnn = ResNet()
 
-        if use_cuda:
-            cnn.cuda()
+        if multiple_gpus_available:
             cnn = DataParallel(cnn)
+        cnn.to(device)
 
     softmax = nn.Softmax(dim=-1)
 
@@ -127,7 +128,7 @@ if __name__ == '__main__':
                 dataset=dataset,
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
-                pin_memory=use_cuda,
+                pin_memory=True if device.type == 'cuda' else False,
                 drop_last=False,
                 num_workers=0
             )

--- a/model-repos/aixia2021/train/SL/train_bert.py
+++ b/model-repos/aixia2021/train/SL/train_bert.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
                 pin_memory=True if device.type == 'cuda' else False,
-                drop_last=False,
+                drop_last=True,
                 num_workers=0
             )
 

--- a/model-repos/aixia2021/train/SL/train_bert.py
+++ b/model-repos/aixia2021/train/SL/train_bert.py
@@ -5,6 +5,7 @@ import os
 from shutil import copy2
 from time import time
 
+import numpy as np
 import torch
 import torch.nn as nn
 import tqdm
@@ -94,9 +95,6 @@ if __name__ == '__main__':
     # For Decider
     decider_cross_entropy = nn.CrossEntropyLoss(reduction='sum')
 
-    # For QGen.
-    _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)
-
     dataset_train = N2NBERTDataset(split='train', add_sep=False, complete_only=True, **dataset_args,
                                    num_turns=args.num_turns)
     dataset_val = N2NBERTDataset(split='val', add_sep=False, complete_only=True, **dataset_args,
@@ -126,8 +124,6 @@ if __name__ == '__main__':
         # Logging
         train_decision_loss = float_tensor()
         val_decision_loss = float_tensor()
-        train_qgen_loss = float_tensor()
-        val_qgen_loss = float_tensor()
         train_guesser_loss = float_tensor()
         val_guesser_loss = float_tensor()
         train_total_loss = float_tensor()
@@ -136,9 +132,7 @@ if __name__ == '__main__':
         training_guesser_accuracy = list()
         validation_guesser_accuracy = list()
         training_ask_accuracy = list()
-        training_guess_accuracy = list()
         validation_ask_accuracy = list()
-        validation_guess_accuracy = list()
 
         for split, dataset in zip(exp_config['splits'], [dataset_train, dataset_val]):
             dataloader = DataLoader(
@@ -235,7 +229,6 @@ if __name__ == '__main__':
                         # Logging variables
                         training_guesser_accuracy.append(guesser_accuracy)
                         training_ask_accuracy.append(ask_accuracy)
-                        training_guess_accuracy.append(guess_accuracy)
                         train_decision_loss = torch.cat([train_decision_loss, decider_loss.data / batch_size])
                         train_guesser_loss = torch.cat([train_guesser_loss, guesser_loss.data])
 
@@ -244,13 +237,11 @@ if __name__ == '__main__':
                     elif split == 'val':
                         validation_guesser_accuracy.append(guesser_accuracy)
                         validation_ask_accuracy.append(ask_accuracy)
-                        validation_guess_accuracy.append(guess_accuracy)
                         val_decision_loss = torch.cat([val_decision_loss, decider_loss.data / batch_size])
                         val_guesser_loss = torch.cat([val_guesser_loss, guesser_loss.data])
 
                         val_total_loss = torch.cat([val_total_loss, loss.data])
 
-        #  and (epoch%args.modulo == 0)
         if exp_config['save_models']:
             model_file = os.path.join(model_dir, ''.join(['model_ensemble_', args.bin_name, '_E_', str(epoch)]))
             torch.save({
@@ -260,33 +251,19 @@ if __name__ == '__main__':
                 'loss': loss,
             }, model_file)
 
-        if epoch % args.modulo != 0:
-            print("Epoch %03d, Time taken %.3f, Total Training Loss %.4f, Total Validation Loss %.4f" % (
-                epoch, time() - start, torch.mean(train_total_loss), torch.mean(val_total_loss)))
-            print("Training Loss:: QGen %.3f, Decider %.3f" % (
-                torch.mean(train_qgen_loss), torch.mean(train_decision_loss)))
-            print("Validation Loss:: QGen %.3f, Decider %.3f" % (
-                torch.mean(val_qgen_loss), torch.mean(val_decision_loss)))
+        print('Epoch %03d, Time taken %.3f, Total Training Loss %.4f, Total Validation Loss %.4f' % (
+        epoch, time() - start, torch.mean(train_total_loss), torch.mean(val_total_loss)))
+        print('Validation Loss:: Decider %.3f, Guesser %.3f' % (
+        torch.mean(val_decision_loss), torch.mean(val_guesser_loss)))
+        print('Training Accuracy:: Guesser %.3f' % (np.mean(training_guesser_accuracy)))
+        print('Validation Accuracy::  Guesser %.3f' % (np.mean(validation_guesser_accuracy)))
 
-        else:
-            print("Epoch %03d, Time taken %.3f, Total Training Loss %.4f, Total Validation Loss %.4f"
-                  % (epoch, time() - start, torch.mean(train_total_loss), torch.mean(val_total_loss)))
-            print("Training Loss:: QGen %.3f, Decider %.3f, Guesser %.3f" % (
-                torch.mean(train_qgen_loss), torch.mean(train_decision_loss), torch.mean(train_guesser_loss)))
-            print("Validation Loss:: QGen %.3f, Decider %.3f, Guesser %.3f" % (
-                torch.mean(val_qgen_loss), torch.mean(val_decision_loss), torch.mean(val_guesser_loss)))
-            print('Training Accuracy:: Guess  %.3f, Guesser %.3f' % (
-                torch.mean(torch.stack(training_guess_accuracy)), torch.mean(torch.tensor(training_guesser_accuracy))))
-            print('Validation Accuracy:: Guess  %.3f, Guesser %.3f' % (
-                torch.mean(torch.stack(validation_guess_accuracy)),
-                torch.mean(torch.tensor(validation_guesser_accuracy))))
-
-            if args.exp_tracker is not None:
-                wandb.log({'Guesser Training Loss': torch.mean(train_guesser_loss),
-                           'Guesser Validation Loss': torch.mean(val_guesser_loss),
-                           'Guesser Training Accuracy': torch.mean(torch.tensor(training_guesser_accuracy)),
-                           'Guesser Validation Accuracy': torch.mean(torch.tensor(validation_guesser_accuracy)),
-                           })
+        if args.exp_tracker is not None:
+            wandb.log({'Guesser Training Loss': torch.mean(train_guesser_loss),
+                       'Guesser Validation Loss': torch.mean(val_guesser_loss),
+                       'Guesser Training Accuracy': torch.mean(torch.tensor(training_guesser_accuracy)),
+                       'Guesser Validation Accuracy': torch.mean(torch.tensor(validation_guesser_accuracy)),
+                       })
 
         if exp_config['save_models']:
-            print("Saved model to %s" % (model_file))
+            print('Saved model to %s' % (model_file))

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -139,7 +139,7 @@ if __name__ == '__main__':
                 dataset=dataset,
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
-                drop_last=False,
+                drop_last=True,
                 pin_memory=use_cuda,
                 num_workers=0
             )

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -20,8 +20,9 @@ from utils.datasets.SL.N2NDataset import N2NDataset
 from utils.eval import calculate_accuracy
 from utils.wrap_var import to_var
 
-# TODO Make this capitalised everywhere to inform it is a global variable
-use_cuda = torch.cuda.is_available()
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+multiple_gpus_available = torch.cuda.device_count() > 1
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -47,7 +48,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     print(args.exp_name)
 
-    device = torch.device('cuda:0') if use_cuda else torch.device('cpu')
     if args.exp_tracker is not None:
         wandb.init(project="lv", entity="we")
 
@@ -65,17 +65,18 @@ if __name__ == '__main__':
         with open(model_dir + 'args.json', 'w') as f:
             json.dump(vars(args), f)  # converting args.namespace to dict
 
-    float_tensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
+    float_tensor = torch.cuda.FloatTensor if device.type == 'cuda' else torch.FloatTensor
     torch.manual_seed(exp_config['seed'])
-    if use_cuda:
+    if device.type == 'cuda':
         torch.cuda.manual_seed_all(exp_config['seed'])
 
     # Init model
     model = EnsembleDeVries(**ensemble_args)
-    if use_cuda:
-        model.cuda()
+    if multiple_gpus_available:
         model = DataParallel(model)
+    model.to(device)
     print(model)
+
     optimizer = optim.Adam(model.parameters(), optimizer_args['lr'])
     # TODO Checkpoint loading
     if args.ckpt is not None:
@@ -91,9 +92,9 @@ if __name__ == '__main__':
     if args.resnet:
         cnn = ResNet()
 
-        if use_cuda:
-            cnn.cuda()
+        if multiple_gpus_available:
             cnn = DataParallel(cnn)
+        cnn.to(device)
 
     softmax = nn.Softmax(dim=-1)
 
@@ -102,9 +103,6 @@ if __name__ == '__main__':
 
     # For Decider
     decider_cross_entropy = nn.CrossEntropyLoss(reduction='sum')
-
-    # For QGen.
-    _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)
 
     if args.resnet:
         # This was for the new image case, we don't use it
@@ -121,7 +119,6 @@ if __name__ == '__main__':
         # Logging
         train_decision_loss = float_tensor()
         val_decision_loss = float_tensor()
-        val_qgen_loss = float_tensor()
         train_guesser_loss = float_tensor()
         val_guesser_loss = float_tensor()
         train_total_loss = float_tensor()
@@ -130,9 +127,7 @@ if __name__ == '__main__':
         training_guesser_accuracy = list()
         validation_guesser_accuracy = list()
         training_ask_accuracy = list()
-        training_guess_accuracy = list()
         validation_ask_accuracy = list()
-        validation_guess_accuracy = list()
 
         for split, dataset in zip(exp_config['splits'], [dataset_train, dataset_val]):
             dataloader = DataLoader(
@@ -140,7 +135,7 @@ if __name__ == '__main__':
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
                 drop_last=True,
-                pin_memory=use_cuda,
+                pin_memory=True if device.type == 'cuda' else False,
                 num_workers=0
             )
 
@@ -150,13 +145,6 @@ if __name__ == '__main__':
                 model.eval()
 
             for i_batch, sample in tqdm.tqdm(enumerate(dataloader), total=len(dataloader), ncols=100):
-                # if i_batch > 60 and args.breaking:
-                #     print('Breaking after processing 60 batch')
-                #     break
-                #
-                # if epoch == 14 and i_batch ==52:
-                #     aa = 0
-
                 sample['tgt_len'], ind = torch.sort(sample['tgt_len'], 0, descending=True)
                 batch_size = ind.size(0)
 
@@ -194,9 +182,6 @@ if __name__ == '__main__':
                     history_len=sample['history_len']
                 )
 
-                # decider_loss += ensemble_args['decider']['guess_weight'] * decider_cross_entropy(decider_out.squeeze(1), sample['decider_tgt'])
-                # guess_accuracy = calculate_accuracy(decider_out.squeeze(1), sample['decider_tgt'])
-
                 guesser_loss += guesser_loss_function(guesser_out * sample['objects_mask'].float(),
                                                       sample['target_obj'])
                 guesser_accuracy = calculate_accuracy(softmax(guesser_out), sample['target_obj'].reshape(-1))
@@ -214,14 +199,12 @@ if __name__ == '__main__':
 
                     # Logging variables
                     training_guesser_accuracy.append(guesser_accuracy)
-                    # training_guess_accuracy.append(guess_accuracy)
                     train_decision_loss = torch.cat([train_decision_loss, decider_loss.data / batch_size])
                     train_guesser_loss = torch.cat([train_guesser_loss, guesser_loss.data])
                     train_total_loss = torch.cat([train_total_loss, loss.data])
 
                 elif split == 'val':
                     validation_guesser_accuracy.append(guesser_accuracy)
-                    # validation_guess_accuracy.append(guess_accuracy)
                     val_decision_loss = torch.cat([val_decision_loss, decider_loss.data / batch_size])
                     val_guesser_loss = torch.cat([val_guesser_loss, guesser_loss.data])
                     val_total_loss = torch.cat([val_total_loss, loss.data])
@@ -237,12 +220,10 @@ if __name__ == '__main__':
 
         print('Epoch %03d, Time taken %.3f, Total Training Loss %.4f, Total Validation Loss %.4f' % (
         epoch, time() - start, torch.mean(train_total_loss), torch.mean(val_total_loss)))
-        print('Validation Loss:: QGen %.3f, Decider %.3f, Guesser %.3f' % (
-        torch.mean(val_qgen_loss), torch.mean(val_decision_loss), torch.mean(val_guesser_loss)))
-        print('Training Accuracy:: Guess  %.3f, Guesser %.3f' % (
-        np.mean(training_guess_accuracy), np.mean(training_guesser_accuracy)))
-        print('Validation Accuracy:: Guess  %.3f, Guesser %.3f' % (
-        np.mean(validation_guess_accuracy), np.mean(validation_guesser_accuracy)))
+        print('Validation Loss:: Decider %.3f, Guesser %.3f' % (
+        torch.mean(val_decision_loss), torch.mean(val_guesser_loss)))
+        print('Training Accuracy:: Guesser %.3f' % (np.mean(training_guesser_accuracy)))
+        print('Validation Accuracy::  Guesser %.3f' % (np.mean(validation_guesser_accuracy)))
 
         if args.exp_tracker is not None:
             wandb.log({'Guesser Training Loss': torch.mean(train_guesser_loss),

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -22,8 +22,9 @@ from utils.datasets.SL.N2NLXMERTDataset import N2NLXMERTDataset
 from utils.eval import calculate_accuracy
 from utils.wrap_var import to_var
 
-# TODO Make this capitalised everywhere to inform it is a global variable
-use_cuda = torch.cuda.is_available()
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+multiple_gpus_available = torch.cuda.device_count() > 1
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -50,7 +51,6 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     print(args.exp_name)
-    device = torch.device('cuda:0') if use_cuda else torch.device('cpu')
     if args.exp_tracker is not None:
         wandb.init(project="lv", entity="we")
 
@@ -105,26 +105,26 @@ if __name__ == '__main__':
         with open(model_dir + 'args.json', 'w') as f:
             json.dump(vars(args), f)  # converting args.namespace to dict
 
-    float_tensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
+    float_tensor = torch.cuda.FloatTensor if device.type == 'cuda' else torch.FloatTensor
     torch.manual_seed(exp_config['seed'])
-    if use_cuda:
+    if device.type == 'cuda':
         torch.cuda.manual_seed_all(exp_config['seed'])
 
     # Init model
     model = LXMERTEnsembleGuesserOnly(**ensemble_args, from_scratch=args.from_scratch)
     # TODO Checkpoint loading
 
-    if use_cuda:
-        model.cuda()
+    if multiple_gpus_available:
         model = DataParallel(model)
+    model.to(device)
     print(model)
 
     if args.resnet:
         cnn = ResNet()
 
-        if use_cuda:
-            cnn.cuda()
+        if multiple_gpus_available:
             cnn = DataParallel(cnn)
+        cnn.to(device)
 
     softmax = nn.Softmax(dim=-1)
 
@@ -190,7 +190,7 @@ if __name__ == '__main__':
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
                 drop_last=False,
-                pin_memory=use_cuda,
+                pin_memory=True if device.type == 'cuda' else False,
                 num_workers=0
             )
 

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -233,17 +233,17 @@ if __name__ == '__main__':
                 ask_accuracy = 0
 
                 decider_out, guesser_out = model(
-                    src_q=sample['src_q'],
-                    tgt_len=sample['tgt_len'],
-                    visual_features=avg_img_features,
-                    spatials=sample['spatials'],
-                    objects=sample['objects'],
-                    target_cat=sample['target_cat'],
+                    src_q=sample['src_q'].to(device),
+                    tgt_len=sample['tgt_len'].to(device),
+                    visual_features=avg_img_features.to(device),
+                    spatials=sample['spatials'].to(device),
+                    objects=sample['objects'].to(device),
+                    target_cat=sample['target_cat'].to(device),
                     history_raw=sample["history_raw"],
-                    fasterrcnn_features=sample["FasterRCNN"]["features"],
-                    fasterrcnn_boxes=sample["FasterRCNN"]["boxes"],
-                    history=sample["history"],
-                    history_len=sample["history_len"]
+                    fasterrcnn_features=sample["FasterRCNN"]["features"].to(device),
+                    fasterrcnn_boxes=sample["FasterRCNN"]["boxes"].to(device),
+                    history=sample["history"].to(device),
+                    history_len=sample["history_len"].to(device)
                 )
 
                 decider_loss += ensemble_args['decider']['guess_weight'] * decider_cross_entropy(decider_out.squeeze(1),

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -189,7 +189,7 @@ if __name__ == '__main__':
                 dataset=dataset,
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
-                drop_last=False,
+                drop_last=True,
                 pin_memory=True if device.type == 'cuda' else False,
                 num_workers=0
             )

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -134,9 +134,6 @@ if __name__ == '__main__':
     # For Decider
     decider_cross_entropy = nn.CrossEntropyLoss()
 
-    # For QGen.
-    _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)
-
     if args.resnet:
         # This was for the new image case, we don't use it
         # Takes too much time.
@@ -171,7 +168,6 @@ if __name__ == '__main__':
         # Logging
         train_decision_loss = float_tensor()
         val_decision_loss = float_tensor()
-        val_qgen_loss = float_tensor()
         train_guesser_loss = float_tensor()
         val_guesser_loss = float_tensor()
         train_total_loss = float_tensor()
@@ -180,9 +176,7 @@ if __name__ == '__main__':
         training_guesser_accuracy = list()
         validation_guesser_accuracy = list()
         training_ask_accuracy = list()
-        training_guess_accuracy = list()
         validation_ask_accuracy = list()
-        validation_guess_accuracy = list()
 
         for split, dataset in zip(exp_config['splits'], [dataset_train, dataset_val]):
             dataloader = DataLoader(
@@ -248,8 +242,6 @@ if __name__ == '__main__':
 
                 decider_loss += ensemble_args['decider']['guess_weight'] * decider_cross_entropy(decider_out.squeeze(1),
                                                                                                  sample['decider_tgt'])
-                guess_accuracy = calculate_accuracy(decider_out.squeeze(1), sample['decider_tgt'])
-
                 guesser_loss += guesser_loss_function(guesser_out * sample['objects_mask'].float(),
                                                       sample['target_obj'])
                 guesser_accuracy = calculate_accuracy(softmax(guesser_out), sample['target_obj'].reshape(-1))
@@ -267,14 +259,12 @@ if __name__ == '__main__':
 
                     # Logging variables
                     training_guesser_accuracy.append(guesser_accuracy)
-                    training_guess_accuracy.append(guess_accuracy)
                     train_decision_loss = torch.cat([train_decision_loss, decider_loss.data / batch_size])
                     train_guesser_loss = torch.cat([train_guesser_loss, guesser_loss.data])
                     train_total_loss = torch.cat([train_total_loss, loss.data])
 
                 elif split == 'val':
                     validation_guesser_accuracy.append(guesser_accuracy)
-                    validation_guess_accuracy.append(guess_accuracy)
                     val_decision_loss = torch.cat([val_decision_loss, decider_loss.data / batch_size])
                     val_guesser_loss = torch.cat([val_guesser_loss, guesser_loss.data])
 
@@ -291,12 +281,10 @@ if __name__ == '__main__':
 
         print("Epoch %03d, Time taken %.3f, Total Training Loss %.4f, Total Validation Loss %.4f" % (
         epoch, time() - start, torch.mean(train_total_loss), torch.mean(val_total_loss)))
-        print("Validation Loss:: QGen %.3f, Decider %.3f, Guesser %.3f" % (
-        torch.mean(val_qgen_loss), torch.mean(val_decision_loss), torch.mean(val_guesser_loss)))
-        print("Training Accuracy:: Guess  %.3f, Guesser %.3f" % (
-        np.mean(training_guess_accuracy), np.mean(training_guesser_accuracy)))
-        print("Validation Accuracy:: Guess  %.3f, Guesser %.3f" % (
-        np.mean(validation_guess_accuracy), np.mean(validation_guesser_accuracy)))
+        print("Validation Loss:: Decider %.3f, Guesser %.3f" % (
+        torch.mean(val_decision_loss), torch.mean(val_guesser_loss)))
+        print("Training Accuracy:: Guesser %.3f" % (np.mean(training_guesser_accuracy)))
+        print("Validation Accuracy:: Guesser %.3f" % (np.mean(validation_guesser_accuracy)))
 
         if args.exp_tracker is not None:
             wandb.log({'Guesser Training Loss': torch.mean(train_guesser_loss),

--- a/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
                 dataset=dataset,
                 batch_size=optimizer_args['batch_size'],
                 shuffle=True,
-                drop_last=False,
+                drop_last=True,
                 pin_memory=True if device.type == 'cuda' else False,
                 num_workers=0
             )


### PR DESCRIPTION
This PR adds a few changes that speed up the models:
- make all tensors directly on device
- decouple the parallelism from just using cuda
- remove the unused calculations in the train files and make the printing uniform
- fixes the trailing RuntimeErrors and the t_total errors related to the batches 