### PR TITLE
show best model at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ As you will notice in the commands below, we are always training with the ```-no
 
 #### Language/Blind models
 
+**Important:** For all models, the ```-test_data_dir <path>``` command line option can be added. This will trigger automatic testing with the saved checkpoint for best epoch. The saved checkpoint will always be shown at the end of training. The test directory should contain all the required files discussed in the [testing section](https://github.com/TamaraAtanasoska/dialogue-history#testing-and-running-experiments) below.
+
 ##### Bling LSTM model (inspired by the original GuessWhat?! model)
 The original GuessWhat!? model that is featured in the original repo is part of the Aixia2021 ensamble as well. To train it, please use: 
 

--- a/model-repos/aixia2021/testing/test_bert.py
+++ b/model-repos/aixia2021/testing/test_bert.py
@@ -18,11 +18,12 @@ from utils.wrap_var import to_var
 # TODO Make this capitalised everywhere to inform it is a global variable
 use_cuda = torch.cuda.is_available()
 
+
 def test_bert_model(best_ckpt, dataset_args, ensemble_args, optimizer_args, exp_config):
     multiple_gpus_available = torch.cuda.device_count() > 1
     device = torch.device("cuda:0") if use_cuda else torch.device("cpu")
-    random.seed(exp_config['seed'])
-    np.random.seed(exp_config['seed'])
+    random.seed(exp_config["seed"])
+    np.random.seed(exp_config["seed"])
     torch.manual_seed(exp_config["seed"])
     if device.type == "cuda":
         torch.cuda.manual_seed_all(exp_config["seed"])
@@ -58,7 +59,7 @@ def test_bert_model(best_ckpt, dataset_args, ensemble_args, optimizer_args, exp_
     targets = []
     with torch.no_grad():
         for i_batch, sample in tqdm.tqdm(
-                enumerate(dataloader), total=len(dataloader), ncols=100
+            enumerate(dataloader), total=len(dataloader), ncols=100
         ):
 
             sample["tgt_len"], ind = torch.sort(sample["tgt_len"], 0, descending=True)
@@ -160,5 +161,10 @@ if __name__ == "__main__":
 
     # Load the Arguments and Hyperparamters
     ensemble_args, dataset_args, optimizer_args, exp_config = preprocess_config(args)
-    test_bert_model(best_ckpt=args.best_ckpt, dataset_args=dataset_args,
-               ensemble_args=ensemble_args, optimizer_args=optimizer_args, exp_config=exp_config)
+    test_bert_model(
+        best_ckpt=args.best_ckpt,
+        dataset_args=dataset_args,
+        ensemble_args=ensemble_args,
+        optimizer_args=optimizer_args,
+        exp_config=exp_config,
+    )

--- a/model-repos/aixia2021/testing/test_bert.py
+++ b/model-repos/aixia2021/testing/test_bert.py
@@ -1,6 +1,8 @@
 # import progressbar
 import argparse
+import random
 
+import numpy as np
 import torch
 import torch.nn as nn
 import tqdm
@@ -8,7 +10,6 @@ from torch.nn import DataParallel
 from torch.utils.data import DataLoader
 
 from models.BERTEnsemble import BERTEnsemble
-from models.CNN import ResNet
 from train.SL.parser import preprocess_config
 from utils.datasets.SL.N2NBERTDataset import N2NBERTDataset
 from utils.eval import calculate_accuracy
@@ -16,6 +17,95 @@ from utils.wrap_var import to_var
 
 # TODO Make this capitalised everywhere to inform it is a global variable
 use_cuda = torch.cuda.is_available()
+
+def test_bert_model(best_ckpt, dataset_args, ensemble_args, optimizer_args, exp_config):
+    multiple_gpus_available = torch.cuda.device_count() > 1
+    device = torch.device("cuda:0") if use_cuda else torch.device("cpu")
+    random.seed(exp_config['seed'])
+    np.random.seed(exp_config['seed'])
+    torch.manual_seed(exp_config["seed"])
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(exp_config["seed"])
+
+    # Init Model
+    model = BERTEnsemble(**ensemble_args)
+
+    if multiple_gpus_available:
+        model = DataParallel(model)
+    model.to(device)
+
+    softmax = nn.Softmax(dim=-1)
+
+    dataset_test = N2NBERTDataset(
+        split="test",
+        add_sep=False,
+        complete_only=True,
+        **dataset_args,
+    )
+
+    checkpoint = torch.load(best_ckpt, map_location=device)
+    model.load_state_dict(checkpoint["model_state_dict"])
+    dataloader = DataLoader(
+        dataset=dataset_test,
+        batch_size=optimizer_args["batch_size"],
+        shuffle=True,
+        pin_memory=use_cuda,
+        drop_last=False,
+        num_workers=0,
+    )
+
+    predictions = []
+    targets = []
+    with torch.no_grad():
+        for i_batch, sample in tqdm.tqdm(
+                enumerate(dataloader), total=len(dataloader), ncols=100
+        ):
+
+            sample["tgt_len"], ind = torch.sort(sample["tgt_len"], 0, descending=True)
+
+            # Get batch
+            for k, v in sample.items():
+                if k == "tgt_len":
+                    sample[k] = to_var(v)
+                elif torch.is_tensor(v):
+                    sample[k] = to_var(v[ind])
+                elif isinstance(v, list):
+                    sample[k] = [v[i] for i in ind]
+
+            # Masking w.r.t decider_tgt
+            masks = list()
+            mask1 = sample["decider_tgt"].data
+
+            if torch.sum(mask1) >= 1:
+                masks.append(torch.nonzero(1 - mask1))
+                masks.append(torch.nonzero(mask1))
+            else:
+                masks.append(torch.nonzero(1 - mask1))
+
+            for idx, mask in enumerate(masks):
+                # When all elements belongs to QGen or Guess only
+                if len(mask) <= 0:
+                    continue
+                mask = mask.squeeze()
+
+                if idx == 1:
+                    mask = mask.reshape(-1)
+                    # decision, guesser_out
+                    guesser_out = model(
+                        history_raw=[sample["history_raw"][i] for i in mask],
+                        tgt_len=sample["tgt_len"][mask],
+                        spatials=sample["spatials"][mask],
+                        objects=sample["objects"][mask],
+                        mask_select=idx,
+                        target_cat=sample["target_cat"][mask],
+                    )
+                    predictions.append(softmax(guesser_out))
+                    targets.append(sample["target_obj"][masks[1].squeeze()].reshape(-1))
+                    # guesser_accuracy = calculate_accuracy(softmax(guesser_out), sample['target_obj'][masks[1].squeeze()].reshape(-1))
+
+    accuracy = calculate_accuracy(torch.cat(predictions), torch.cat(targets))
+    print(f"Guesser Accuracy: {accuracy}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -67,111 +157,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     print(args.exp_name)
-    device = torch.device("cuda:0") if use_cuda else torch.device("cpu")
+
     # Load the Arguments and Hyperparamters
     ensemble_args, dataset_args, optimizer_args, exp_config = preprocess_config(args)
-    float_tensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
-    torch.manual_seed(exp_config["seed"])
-    if use_cuda:
-        torch.cuda.manual_seed_all(exp_config["seed"])
-
-    # Init Model
-    model = BERTEnsemble(**ensemble_args, from_scratch=args.from_scratch)
-    # TODO Checkpoint loading
-
-    if use_cuda:
-        model.cuda()
-        model = DataParallel(model)
-    print(model)
-    if args.resnet:
-        cnn = ResNet()
-
-        if use_cuda:
-            cnn.cuda()
-            cnn = DataParallel(cnn)
-
-    softmax = nn.Softmax(dim=-1)
-
-    # For Guesser
-    guesser_loss_function = nn.CrossEntropyLoss()
-
-    # For QGen.
-    _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)
-
-    dataset_test = N2NBERTDataset(
-        split="test",
-        add_sep=False,
-        complete_only=True,
-        **dataset_args,
-        num_turns=args.num_turns,
-    )
-
-    checkpoint = torch.load(args.best_ckpt, map_location=device)
-    model.load_state_dict(checkpoint["model_state_dict"])
-    test_guesser_accuracy = list()
-    dataloader = DataLoader(
-        dataset=dataset_test,
-        batch_size=optimizer_args["batch_size"],
-        shuffle=True,
-        pin_memory=use_cuda,
-        drop_last=False,
-        num_workers=0,
-    )
-
-    predictions = []
-    targets = []
-    with torch.no_grad():
-        for i_batch, sample in tqdm.tqdm(
-            enumerate(dataloader), total=len(dataloader), ncols=100
-        ):
-            if i_batch > 60 and args.breaking:
-                print("Breaking after processing 60 batch")
-                break
-
-            sample["tgt_len"], ind = torch.sort(sample["tgt_len"], 0, descending=True)
-            batch_size = ind.size(0)
-
-            # Get batch
-            for k, v in sample.items():
-                if k == "tgt_len":
-                    sample[k] = to_var(v)
-                elif torch.is_tensor(v):
-                    sample[k] = to_var(v[ind])
-                elif isinstance(v, list):
-                    sample[k] = [v[i] for i in ind]
-
-            # Masking w.r.t decider_tgt
-            masks = list()
-            mask1 = sample["decider_tgt"].data
-
-            if torch.sum(mask1) >= 1:
-                masks.append(torch.nonzero(1 - mask1))
-                masks.append(torch.nonzero(mask1))
-            else:
-                masks.append(torch.nonzero(1 - mask1))
-
-            guesser_accuracy = torch.Tensor([0])
-
-            for idx, mask in enumerate(masks):
-                # When all elements belongs to QGen or Guess only
-                if len(mask) <= 0:
-                    continue
-                mask = mask.squeeze()
-
-                if idx == 1:
-                    mask = mask.reshape(-1)
-                    # decision, guesser_out
-                    guesser_out = model(
-                        history_raw=[sample["history_raw"][i] for i in mask],
-                        tgt_len=sample["tgt_len"][mask],
-                        spatials=sample["spatials"][mask],
-                        objects=sample["objects"][mask],
-                        mask_select=idx,
-                        target_cat=sample["target_cat"][mask],
-                    )
-                    predictions.append(softmax(guesser_out))
-                    targets.append(sample["target_obj"][masks[1].squeeze()].reshape(-1))
-                    # guesser_accuracy = calculate_accuracy(softmax(guesser_out), sample['target_obj'][masks[1].squeeze()].reshape(-1))
-
-    accuracy = calculate_accuracy(torch.cat(predictions), torch.cat(targets))
-    print(f"Guesser Accuracy: {accuracy}")
+    test_bert_model(best_ckpt=args.best_ckpt, dataset_args=dataset_args,
+               ensemble_args=ensemble_args, optimizer_args=optimizer_args, exp_config=exp_config)

--- a/model-repos/aixia2021/testing/test_lstm.py
+++ b/model-repos/aixia2021/testing/test_lstm.py
@@ -1,5 +1,7 @@
 import argparse
+import random
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -17,11 +19,16 @@ from utils.wrap_var import to_var
 # TODO Make this capitalised everywhere to inform it is a global variable
 use_cuda = torch.cuda.is_available()
 
-def test_model(best_ckpt, model_type, dataset_args, ensemble_args, optimizer_args):
+def test_model(best_ckpt, model_type, dataset_args, ensemble_args, optimizer_args, exp_config):
     device = torch.device("cuda:0") if use_cuda else torch.device("cpu")
     multiple_gpus_available = torch.cuda.device_count() > 1
-    # Init model
+    random.seed(exp_config['seed'])
+    np.random.seed(exp_config['seed'])
+    torch.manual_seed(exp_config["seed"])
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(exp_config["seed"])
 
+    # Init model
     if model_type == "blind":
         model = EnsembleDeVries(**ensemble_args)
     else: # model_type == "visual":
@@ -133,4 +140,4 @@ if __name__ == "__main__":
 
     ensemble_args, dataset_args, optimizer_args, exp_config = preprocess_config(args)
 
-    test_model(model_type=args.model_type, best_ckpt=args.best_ckpt, dataset_args=dataset_args, ensemble_args=ensemble_args, optimizer_args=optimizer_args)
+    test_model(model_type=args.model_type, best_ckpt=args.best_ckpt, dataset_args=dataset_args, ensemble_args=ensemble_args, optimizer_args=optimizer_args, exp_config=exp_config)

--- a/model-repos/aixia2021/testing/test_lstm.py
+++ b/model-repos/aixia2021/testing/test_lstm.py
@@ -19,11 +19,14 @@ from utils.wrap_var import to_var
 # TODO Make this capitalised everywhere to inform it is a global variable
 use_cuda = torch.cuda.is_available()
 
-def test_model(best_ckpt, model_type, dataset_args, ensemble_args, optimizer_args, exp_config):
+
+def test_model(
+    best_ckpt, model_type, dataset_args, ensemble_args, optimizer_args, exp_config
+):
     device = torch.device("cuda:0") if use_cuda else torch.device("cpu")
     multiple_gpus_available = torch.cuda.device_count() > 1
-    random.seed(exp_config['seed'])
-    np.random.seed(exp_config['seed'])
+    random.seed(exp_config["seed"])
+    np.random.seed(exp_config["seed"])
     torch.manual_seed(exp_config["seed"])
     if device.type == "cuda":
         torch.cuda.manual_seed_all(exp_config["seed"])
@@ -31,7 +34,7 @@ def test_model(best_ckpt, model_type, dataset_args, ensemble_args, optimizer_arg
     # Init model
     if model_type == "blind":
         model = EnsembleDeVries(**ensemble_args)
-    else: # model_type == "visual":
+    else:  # model_type == "visual":
         model = EnsembleGuesserOnly(**ensemble_args)
     if multiple_gpus_available:
         model = DataParallel(model)
@@ -56,7 +59,7 @@ def test_model(best_ckpt, model_type, dataset_args, ensemble_args, optimizer_arg
     targets = []
     with torch.no_grad():
         for i_batch, sample in tqdm.tqdm(
-                enumerate(dataloader), total=len(dataloader), ncols=100
+            enumerate(dataloader), total=len(dataloader), ncols=100
         ):
 
             sample["tgt_len"], ind = torch.sort(sample["tgt_len"], 0, descending=True)
@@ -140,4 +143,11 @@ if __name__ == "__main__":
 
     ensemble_args, dataset_args, optimizer_args, exp_config = preprocess_config(args)
 
-    test_model(model_type=args.model_type, best_ckpt=args.best_ckpt, dataset_args=dataset_args, ensemble_args=ensemble_args, optimizer_args=optimizer_args, exp_config=exp_config)
+    test_model(
+        model_type=args.model_type,
+        best_ckpt=args.best_ckpt,
+        dataset_args=dataset_args,
+        ensemble_args=ensemble_args,
+        optimizer_args=optimizer_args,
+        exp_config=exp_config,
+    )

--- a/model-repos/aixia2021/testing/test_lxmert.py
+++ b/model-repos/aixia2021/testing/test_lxmert.py
@@ -10,7 +10,6 @@ import tqdm
 from torch.nn import DataParallel
 from torch.utils.data import DataLoader
 
-from models.CNN import ResNet
 from models.LXMERTEnsembleGuesserOnly import LXMERTEnsembleGuesserOnly
 from train.SL.parser import preprocess_config
 from utils.datasets.SL.N2NLXMERTDataset import N2NLXMERTDataset
@@ -19,6 +18,81 @@ from utils.wrap_var import to_var
 
 # TODO Make this capitalised everywhere to inform it is a global variable
 use_cuda = torch.cuda.is_available()
+
+def test_lxmert_model(imgid2fasterRCNNfeatures, best_ckpt, dataset_args, ensemble_args, optimizer_args,exp_config):
+    multiple_gpus_available = torch.cuda.device_count() > 1
+    device = torch.device('cuda:0') if use_cuda else torch.device('cpu')
+    random.seed(exp_config['seed'])
+    np.random.seed(exp_config['seed'])
+    torch.manual_seed(exp_config["seed"])
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(exp_config["seed"])
+
+    # Init model
+    model = LXMERTEnsembleGuesserOnly(**ensemble_args)
+
+    if multiple_gpus_available:
+        model = DataParallel(model)
+    model.to(device)
+
+    softmax = nn.Softmax(dim=-1)
+    dataset_test = N2NLXMERTDataset(split='test', **dataset_args, complete_only=True,
+                                    imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures)
+
+    checkpoint = torch.load(best_ckpt, map_location=device)
+    model.load_state_dict(checkpoint['model_state_dict'])
+    predictions = []
+    targets = []
+
+    dataloader = DataLoader(
+        dataset=dataset_test,
+        batch_size=optimizer_args['batch_size'],
+        shuffle=True,
+        drop_last=False,
+        pin_memory=use_cuda,
+        num_workers=0
+    )
+    with torch.no_grad():
+        for i_batch, sample in tqdm.tqdm(enumerate(dataloader), total=len(dataloader), ncols=100):
+            if i_batch > 60 and args.breaking:
+                print('Breaking after processing 60 batch')
+                break
+
+            sample['tgt_len'], ind = torch.sort(sample['tgt_len'], 0, descending=True)
+
+            # Get batch
+            for k, v in sample.items():
+                if k == 'tgt_len':
+                    sample[k] = to_var(v)
+                elif torch.is_tensor(v):
+                    sample[k] = to_var(v[ind])
+                elif isinstance(v, list):
+                    sample[k] = [v[i] for i in ind]
+
+
+            avg_img_features = sample['image']
+
+            decider_out, guesser_out = model(
+                src_q=sample['src_q'],
+                tgt_len=sample['tgt_len'],
+                visual_features=avg_img_features,
+                spatials=sample['spatials'],
+                objects=sample['objects'],
+                target_cat=sample['target_cat'],
+                history_raw=sample["history_raw"],
+                fasterrcnn_features=sample["FasterRCNN"]["features"],
+                fasterrcnn_boxes=sample["FasterRCNN"]["boxes"],
+                history=sample["history"],
+                history_len=sample["history_len"]
+            )
+
+            # guesser_accuracy = calculate_accuracy(softmax(guesser_out), sample['target_obj'].reshape(-1))
+            predictions.append(softmax(guesser_out))
+            targets.append(sample['target_obj'].reshape(-1))
+
+        accuracy = calculate_accuracy(torch.cat(predictions), torch.cat(targets))
+        print(f'Guesser Accuracy: {accuracy}')
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -42,11 +116,8 @@ if __name__ == '__main__':
     parser.add_argument('-model_type', type=str, default='blind', help='blind or visual')
 
     args = parser.parse_args()
-    print(args.exp_name)
-    device = torch.device('cuda:0') if use_cuda else torch.device('cpu')
 
     ensemble_args, dataset_args, optimizer_args, exp_config = preprocess_config(args)
-
     print("Loading MSCOCO bottomup index from: {}".format(dataset_args["FasterRCNN"]["mscoco_bottomup_index"]))
     with open(dataset_args["FasterRCNN"]["mscoco_bottomup_index"]) as in_file:
         mscoco_bottomup_index = json.load(in_file)
@@ -81,99 +152,6 @@ if __name__ == '__main__':
         imgid2fasterRCNNfeatures[mscoco_id]["img_h"] = img_h[mscoco_pos]
         imgid2fasterRCNNfeatures[mscoco_id]["img_w"] = img_w[mscoco_pos]
 
-    random.seed(exp_config['seed'])
-    np.random.seed(exp_config['seed'])
 
-    float_tensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
-    torch.manual_seed(exp_config['seed'])
-    if use_cuda:
-        torch.cuda.manual_seed_all(exp_config['seed'])
-
-    # Init model
-    model = LXMERTEnsembleGuesserOnly(**ensemble_args, from_scratch=args.from_scratch)
-
-    if use_cuda:
-        model.cuda()
-        model = DataParallel(model)
-    print(model)
-
-    if args.resnet:
-        cnn = ResNet()
-
-        if use_cuda:
-            cnn.cuda()
-            cnn = DataParallel(cnn)
-
-    softmax = nn.Softmax(dim=-1)
-
-    # For Guesser
-    guesser_loss_function = nn.CrossEntropyLoss()
-
-    # For QGen.
-    _cross_entropy = nn.CrossEntropyLoss(ignore_index=0)
-
-    dataset_test = N2NLXMERTDataset(split='test', **dataset_args, complete_only=True,
-                                     imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures, num_turns=args.num_turns)
-
-
-
-    checkpoint = torch.load(args.best_ckpt, map_location=device)
-    model.load_state_dict(checkpoint['model_state_dict'])
-    predictions = []
-    targets = []
-
-    dataloader = DataLoader(
-        dataset=dataset_test,
-        batch_size=optimizer_args['batch_size'],
-        shuffle=True,
-        drop_last=False,
-        pin_memory=use_cuda,
-        num_workers=0
-    )
-    with torch.no_grad():
-        for i_batch, sample in tqdm.tqdm(enumerate(dataloader), total=len(dataloader), ncols=100):
-            if i_batch > 60 and args.breaking:
-                print('Breaking after processing 60 batch')
-                break
-
-            sample['tgt_len'], ind = torch.sort(sample['tgt_len'], 0, descending=True)
-            batch_size = ind.size(0)
-
-            # Get batch
-            for k, v in sample.items():
-                if k == 'tgt_len':
-                    sample[k] = to_var(v)
-                elif torch.is_tensor(v):
-                    sample[k] = to_var(v[ind])
-                elif isinstance(v, list):
-                    sample[k] = [v[i] for i in ind]
-
-            if args.resnet:
-                # This is done so that during backprop the gradients dont flow through the ResNet
-                img_features, avg_img_features = cnn(to_var(sample['image'].data, True))
-                img_features, avg_img_features = to_var(img_features.data), to_var(avg_img_features.data)
-            else:
-                avg_img_features = sample['image']
-
-
-            decider_out, guesser_out = model(
-                src_q=sample['src_q'],
-                tgt_len=sample['tgt_len'],
-                visual_features=avg_img_features,
-                spatials=sample['spatials'],
-                objects=sample['objects'],
-                target_cat=sample['target_cat'],
-                history_raw=sample["history_raw"],
-                fasterrcnn_features=sample["FasterRCNN"]["features"],
-                fasterrcnn_boxes=sample["FasterRCNN"]["boxes"],
-                history=sample["history"],
-                history_len=sample["history_len"]
-            )
-
-
-            #guesser_accuracy = calculate_accuracy(softmax(guesser_out), sample['target_obj'].reshape(-1))
-            predictions.append(softmax(guesser_out))
-            targets.append(sample['target_obj'].reshape(-1))
-
-        accuracy = calculate_accuracy(torch.cat(predictions), torch.cat(targets))
-        print(f'Guesser Accuracy: {accuracy}')
+    test_lxmert_model(imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures, best_ckpt=args.best_ckpt, dataset_args=dataset_args,
+                    ensemble_args=ensemble_args, optimizer_args=optimizer_args, exp_config=exp_config)

--- a/model-repos/aixia2021/testing/test_lxmert.py
+++ b/model-repos/aixia2021/testing/test_lxmert.py
@@ -19,11 +19,19 @@ from utils.wrap_var import to_var
 # TODO Make this capitalised everywhere to inform it is a global variable
 use_cuda = torch.cuda.is_available()
 
-def test_lxmert_model(imgid2fasterRCNNfeatures, best_ckpt, dataset_args, ensemble_args, optimizer_args,exp_config):
+
+def test_lxmert_model(
+    imgid2fasterRCNNfeatures,
+    best_ckpt,
+    dataset_args,
+    ensemble_args,
+    optimizer_args,
+    exp_config,
+):
     multiple_gpus_available = torch.cuda.device_count() > 1
-    device = torch.device('cuda:0') if use_cuda else torch.device('cpu')
-    random.seed(exp_config['seed'])
-    np.random.seed(exp_config['seed'])
+    device = torch.device("cuda:0") if use_cuda else torch.device("cpu")
+    random.seed(exp_config["seed"])
+    np.random.seed(exp_config["seed"])
     torch.manual_seed(exp_config["seed"])
     if device.type == "cuda":
         torch.cuda.manual_seed_all(exp_config["seed"])
@@ -36,89 +44,123 @@ def test_lxmert_model(imgid2fasterRCNNfeatures, best_ckpt, dataset_args, ensembl
     model.to(device)
 
     softmax = nn.Softmax(dim=-1)
-    dataset_test = N2NLXMERTDataset(split='test', **dataset_args, complete_only=True,
-                                    imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures)
+    dataset_test = N2NLXMERTDataset(
+        split="test",
+        **dataset_args,
+        complete_only=True,
+        imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures,
+    )
 
     checkpoint = torch.load(best_ckpt, map_location=device)
-    model.load_state_dict(checkpoint['model_state_dict'])
+    model.load_state_dict(checkpoint["model_state_dict"])
     predictions = []
     targets = []
 
     dataloader = DataLoader(
         dataset=dataset_test,
-        batch_size=optimizer_args['batch_size'],
+        batch_size=optimizer_args["batch_size"],
         shuffle=True,
         drop_last=False,
         pin_memory=use_cuda,
-        num_workers=0
+        num_workers=0,
     )
     with torch.no_grad():
-        for i_batch, sample in tqdm.tqdm(enumerate(dataloader), total=len(dataloader), ncols=100):
+        for i_batch, sample in tqdm.tqdm(
+            enumerate(dataloader), total=len(dataloader), ncols=100
+        ):
             if i_batch > 60 and args.breaking:
-                print('Breaking after processing 60 batch')
+                print("Breaking after processing 60 batch")
                 break
 
-            sample['tgt_len'], ind = torch.sort(sample['tgt_len'], 0, descending=True)
+            sample["tgt_len"], ind = torch.sort(sample["tgt_len"], 0, descending=True)
 
             # Get batch
             for k, v in sample.items():
-                if k == 'tgt_len':
+                if k == "tgt_len":
                     sample[k] = to_var(v)
                 elif torch.is_tensor(v):
                     sample[k] = to_var(v[ind])
                 elif isinstance(v, list):
                     sample[k] = [v[i] for i in ind]
 
-
-            avg_img_features = sample['image']
+            avg_img_features = sample["image"]
 
             decider_out, guesser_out = model(
-                src_q=sample['src_q'],
-                tgt_len=sample['tgt_len'],
+                src_q=sample["src_q"],
+                tgt_len=sample["tgt_len"],
                 visual_features=avg_img_features,
-                spatials=sample['spatials'],
-                objects=sample['objects'],
-                target_cat=sample['target_cat'],
+                spatials=sample["spatials"],
+                objects=sample["objects"],
+                target_cat=sample["target_cat"],
                 history_raw=sample["history_raw"],
                 fasterrcnn_features=sample["FasterRCNN"]["features"],
                 fasterrcnn_boxes=sample["FasterRCNN"]["boxes"],
                 history=sample["history"],
-                history_len=sample["history_len"]
+                history_len=sample["history_len"],
             )
 
             # guesser_accuracy = calculate_accuracy(softmax(guesser_out), sample['target_obj'].reshape(-1))
             predictions.append(softmax(guesser_out))
-            targets.append(sample['target_obj'].reshape(-1))
+            targets.append(sample["target_obj"].reshape(-1))
 
         accuracy = calculate_accuracy(torch.cat(predictions), torch.cat(targets))
-        print(f'Guesser Accuracy: {accuracy}')
+        print(f"Guesser Accuracy: {accuracy}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-data_dir", type=str, default="data", help='Data Directory')
-    parser.add_argument("-config", type=str, default="config/SL/config_bert.json", help='Config file')
-    parser.add_argument("-exp_name", type=str, help='Experiment Name')
-    parser.add_argument("-bin_name", type=str, default='', help='Name of the trained model file')
-    parser.add_argument("-my_cpu", action='store_true',
-                        help='To select number of workers for dataloader. CAUTION: If using your own system then make this True')
-    parser.add_argument("-breaking", action='store_true',
-                        help='To Break training after 5 batch, for code testing purpose')
-    parser.add_argument("-resnet", action='store_true',
-                        help='This flag will cause the program to use the image features from the ResNet forward pass instead of the precomputed ones.')
-    parser.add_argument("-modulo", type=int, default=1,
-                        help='This flag will cause the guesser to be updated every modulo number of epochs')
-    parser.add_argument("-no_decider", action='store_true', help='This flag will cause the decider to be turned off')
+    parser.add_argument("-data_dir", type=str, default="data", help="Data Directory")
+    parser.add_argument(
+        "-config", type=str, default="config/SL/config_bert.json", help="Config file"
+    )
+    parser.add_argument("-exp_name", type=str, help="Experiment Name")
+    parser.add_argument(
+        "-bin_name", type=str, default="", help="Name of the trained model file"
+    )
+    parser.add_argument(
+        "-my_cpu",
+        action="store_true",
+        help="To select number of workers for dataloader. CAUTION: If using your own system then make this True",
+    )
+    parser.add_argument(
+        "-breaking",
+        action="store_true",
+        help="To Break training after 5 batch, for code testing purpose",
+    )
+    parser.add_argument(
+        "-resnet",
+        action="store_true",
+        help="This flag will cause the program to use the image features from the ResNet forward pass instead of the precomputed ones.",
+    )
+    parser.add_argument(
+        "-modulo",
+        type=int,
+        default=1,
+        help="This flag will cause the guesser to be updated every modulo number of epochs",
+    )
+    parser.add_argument(
+        "-no_decider",
+        action="store_true",
+        help="This flag will cause the decider to be turned off",
+    )
     parser.add_argument("-num_turns", type=int, default=None)
     parser.add_argument("--preloaded", type=bool, default=False)
     parser.add_argument("-from_scratch", type=bool, default=False)
-    parser.add_argument('-best_ckpt', type=str, default='', help='Name of the trained model file')
-    parser.add_argument('-model_type', type=str, default='blind', help='blind or visual')
+    parser.add_argument(
+        "-best_ckpt", type=str, default="", help="Name of the trained model file"
+    )
+    parser.add_argument(
+        "-model_type", type=str, default="blind", help="blind or visual"
+    )
 
     args = parser.parse_args()
 
     ensemble_args, dataset_args, optimizer_args, exp_config = preprocess_config(args)
-    print("Loading MSCOCO bottomup index from: {}".format(dataset_args["FasterRCNN"]["mscoco_bottomup_index"]))
+    print(
+        "Loading MSCOCO bottomup index from: {}".format(
+            dataset_args["FasterRCNN"]["mscoco_bottomup_index"]
+        )
+    )
     with open(dataset_args["FasterRCNN"]["mscoco_bottomup_index"]) as in_file:
         mscoco_bottomup_index = json.load(in_file)
         image_id2image_pos = mscoco_bottomup_index["image_id2image_pos"]
@@ -126,32 +168,55 @@ if __name__ == '__main__':
         img_h = mscoco_bottomup_index["img_h"]
         img_w = mscoco_bottomup_index["img_w"]
 
-    print("Loading MSCOCO bottomup features from: {}".format(dataset_args["FasterRCNN"]["mscoco_bottomup_features"]))
+    print(
+        "Loading MSCOCO bottomup features from: {}".format(
+            dataset_args["FasterRCNN"]["mscoco_bottomup_features"]
+        )
+    )
     mscoco_bottomup_features = None
     if args.preloaded:
         print("Loading preloaded MS-COCO Bottom-Up features")
-        mscoco_bottomup_features = sharearray.cache("mscoco_vectorized_features", lambda: None)
+        mscoco_bottomup_features = sharearray.cache(
+            "mscoco_vectorized_features", lambda: None
+        )
         mscoco_bottomup_features = np.array(mscoco_bottomup_features)
     else:
-        mscoco_bottomup_features = np.load(dataset_args["FasterRCNN"]["mscoco_bottomup_features"])
+        mscoco_bottomup_features = np.load(
+            dataset_args["FasterRCNN"]["mscoco_bottomup_features"]
+        )
         mscoco_bottomup_features = mscoco_bottomup_features.f.arr_0
-    print("Loading MSCOCO bottomup boxes from: {}".format(dataset_args["FasterRCNN"]["mscoco_bottomup_boxes"]))
+    print(
+        "Loading MSCOCO bottomup boxes from: {}".format(
+            dataset_args["FasterRCNN"]["mscoco_bottomup_boxes"]
+        )
+    )
     mscoco_bottomup_boxes = None
     if args.preloaded:
         print("Loading preloaded MS-COCO Bottom-Up boxes")
-        mscoco_bottomup_boxes = sharearray.cache("mscoco_vectorized_boxes", lambda: None)
+        mscoco_bottomup_boxes = sharearray.cache(
+            "mscoco_vectorized_boxes", lambda: None
+        )
         mscoco_bottomup_boxes = np.array(mscoco_bottomup_boxes)
     else:
-        mscoco_bottomup_boxes = np.load(dataset_args["FasterRCNN"]["mscoco_bottomup_boxes"])
+        mscoco_bottomup_boxes = np.load(
+            dataset_args["FasterRCNN"]["mscoco_bottomup_boxes"]
+        )
 
     imgid2fasterRCNNfeatures = {}
     for mscoco_id, mscoco_pos in image_id2image_pos.items():
         imgid2fasterRCNNfeatures[mscoco_id] = dict()
-        imgid2fasterRCNNfeatures[mscoco_id]["features"] = mscoco_bottomup_features[mscoco_pos]
+        imgid2fasterRCNNfeatures[mscoco_id]["features"] = mscoco_bottomup_features[
+            mscoco_pos
+        ]
         imgid2fasterRCNNfeatures[mscoco_id]["boxes"] = mscoco_bottomup_boxes[mscoco_pos]
         imgid2fasterRCNNfeatures[mscoco_id]["img_h"] = img_h[mscoco_pos]
         imgid2fasterRCNNfeatures[mscoco_id]["img_w"] = img_w[mscoco_pos]
 
-
-    test_lxmert_model(imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures, best_ckpt=args.best_ckpt, dataset_args=dataset_args,
-                    ensemble_args=ensemble_args, optimizer_args=optimizer_args, exp_config=exp_config)
+    test_lxmert_model(
+        imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures,
+        best_ckpt=args.best_ckpt,
+        dataset_args=dataset_args,
+        ensemble_args=ensemble_args,
+        optimizer_args=optimizer_args,
+        exp_config=exp_config,
+    )

--- a/model-repos/aixia2021/train/SL/train_bert.py
+++ b/model-repos/aixia2021/train/SL/train_bert.py
@@ -76,7 +76,9 @@ if __name__ == "__main__":
         help="track experiment using various framework, currently supports W&B: use wandb",
         default=None,
     )
-    parser.add_argument("-test_data_dir", type=str, default=None, help="Test data directory")
+    parser.add_argument(
+        "-test_data_dir", type=str, default=None, help="Test data directory"
+    )
 
     args = parser.parse_args()
     print(args.exp_name)
@@ -135,14 +137,14 @@ if __name__ == "__main__":
         add_sep=False,
         complete_only=True,
         **dataset_args,
-        num_turns=args.num_turns
+        num_turns=args.num_turns,
     )
     dataset_val = N2NBERTDataset(
         split="val",
         add_sep=False,
         complete_only=True,
         **dataset_args,
-        num_turns=args.num_turns
+        num_turns=args.num_turns,
     )
 
     # TODO Use different optimizers for different modules if required.
@@ -370,11 +372,15 @@ if __name__ == "__main__":
         model_dir,
         "".join(["model_ensemble_", args.bin_name, "_E_", str(best_epoch)]),
     )
-    print(f'Best model: {best_model_file}')
+    print(f"Best model: {best_model_file}")
 
     if args.test_data_dir is not None:
         dataset_args["data_dir"] = args.test_data_dir
-        print('Evaluating over test data using best model')
-        test_bert_model(best_ckpt=best_model_file, dataset_args=dataset_args,
-                   ensemble_args=ensemble_args, optimizer_args=optimizer_args, exp_config=exp_config)
-
+        print("Evaluating over test data using best model")
+        test_bert_model(
+            best_ckpt=best_model_file,
+            dataset_args=dataset_args,
+            ensemble_args=ensemble_args,
+            optimizer_args=optimizer_args,
+            exp_config=exp_config,
+        )

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -145,6 +145,7 @@ if __name__ == "__main__":
         dataset_val = N2NDataset(
             split="val", **dataset_args, complete_only=True, num_turns=args.num_turns
         )
+    val_accuracies = []
 
     for epoch in range(start_e, optimizer_args["no_epochs"]):
         start = time()
@@ -293,6 +294,7 @@ if __name__ == "__main__":
             "Validation Accuracy::  Guesser %.3f"
             % (np.mean(validation_guesser_accuracy))
         )
+        val_accuracies.append(np.mean(validation_guesser_accuracy))
 
         if args.exp_tracker is not None:
             wandb.log(
@@ -310,3 +312,10 @@ if __name__ == "__main__":
 
         if exp_config["save_models"]:
             print("Saved model to %s" % (model_file))
+
+    best_epoch = np.argmax(val_accuracies)
+    best_model_file = os.path.join(
+        model_dir,
+        "".join(["model_ensemble_", args.bin_name, "_E_", str(best_epoch)]),
+    )
+    print(f'Best model: {best_model_file}')

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -15,6 +15,7 @@ from torch.utils.data import DataLoader
 
 from models.CNN import ResNet
 from models.EnsembleDeVries import EnsembleDeVries
+from testing.test_lstm import test_model
 from train.SL.parser import preprocess_config
 from utils.datasets.SL.N2NDataset import N2NDataset
 from utils.eval import calculate_accuracy
@@ -70,6 +71,7 @@ if __name__ == "__main__":
         help="track experiment using various framework, currently supports W&B: use wandb",
         default=None,
     )
+    parser.add_argument("-test_data_dir", type=str, default=None, help="Test data directory")
 
     args = parser.parse_args()
     print(args.exp_name)
@@ -115,9 +117,11 @@ if __name__ == "__main__":
         optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         start_e = checkpoint["epoch"] + 1
         loss = checkpoint["loss"]
+        val_accuracies = checkpoint["val_accuracies"]
     else:
         start_e = 0
         loss = 0
+        val_accuracies = []
 
     if args.resnet:
         cnn = ResNet()
@@ -145,7 +149,6 @@ if __name__ == "__main__":
         dataset_val = N2NDataset(
             split="val", **dataset_args, complete_only=True, num_turns=args.num_turns
         )
-    val_accuracies = []
 
     for epoch in range(start_e, optimizer_args["no_epochs"]):
         start = time()
@@ -272,6 +275,7 @@ if __name__ == "__main__":
                     "model_state_dict": model.state_dict(),
                     "optimizer_state_dict": optimizer.state_dict(),
                     "loss": loss,
+                    "val_accuracies": val_accuracies,
                 },
                 model_file,
             )
@@ -319,3 +323,8 @@ if __name__ == "__main__":
         "".join(["model_ensemble_", args.bin_name, "_E_", str(best_epoch)]),
     )
     print(f'Best model: {best_model_file}')
+
+    if args.test_data_dir is not None:
+        dataset_args["data_dir"] = args.test_data_dir
+        print('Evaluating over test data using best model')
+        test_model(model_type='blind', best_ckpt=best_model_file,dataset_args=dataset_args, ensemble_args=ensemble_args, optimizer_args=optimizer_args)

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -71,7 +71,9 @@ if __name__ == "__main__":
         help="track experiment using various framework, currently supports W&B: use wandb",
         default=None,
     )
-    parser.add_argument("-test_data_dir", type=str, default=None, help="Test data directory")
+    parser.add_argument(
+        "-test_data_dir", type=str, default=None, help="Test data directory"
+    )
 
     args = parser.parse_args()
     print(args.exp_name)
@@ -322,9 +324,16 @@ if __name__ == "__main__":
         model_dir,
         "".join(["model_ensemble_", args.bin_name, "_E_", str(best_epoch)]),
     )
-    print(f'Best model: {best_model_file}')
+    print(f"Best model: {best_model_file}")
 
     if args.test_data_dir is not None:
         dataset_args["data_dir"] = args.test_data_dir
-        print('Evaluating over test data using best model')
-        test_model(model_type='blind', best_ckpt=best_model_file,dataset_args=dataset_args, ensemble_args=ensemble_args, optimizer_args=optimizer_args,exp_config=exp_config)
+        print("Evaluating over test data using best model")
+        test_model(
+            model_type="blind",
+            best_ckpt=best_model_file,
+            dataset_args=dataset_args,
+            ensemble_args=ensemble_args,
+            optimizer_args=optimizer_args,
+            exp_config=exp_config,
+        )

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -327,4 +327,4 @@ if __name__ == "__main__":
     if args.test_data_dir is not None:
         dataset_args["data_dir"] = args.test_data_dir
         print('Evaluating over test data using best model')
-        test_model(model_type='blind', best_ckpt=best_model_file,dataset_args=dataset_args, ensemble_args=ensemble_args, optimizer_args=optimizer_args)
+        test_model(model_type='blind', best_ckpt=best_model_file,dataset_args=dataset_args, ensemble_args=ensemble_args, optimizer_args=optimizer_args,exp_config=exp_config)

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -75,7 +75,9 @@ if __name__ == "__main__":
         help="track experiment using various framework, currently supports W&B: use wandb",
         default=None,
     )
-    parser.add_argument("-test_data_dir", type=str, default=None, help="Test data directory")
+    parser.add_argument(
+        "-test_data_dir", type=str, default=None, help="Test data directory"
+    )
 
     args = parser.parse_args()
     print(args.exp_name)
@@ -197,14 +199,14 @@ if __name__ == "__main__":
             **dataset_args,
             complete_only=True,
             imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures,
-            num_turns=args.num_turns
+            num_turns=args.num_turns,
         )
         dataset_val = N2NLXMERTDataset(
             split="val",
             **dataset_args,
             complete_only=True,
             imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures,
-            num_turns=args.num_turns
+            num_turns=args.num_turns,
         )
 
     print("Initializing the optimizer...")
@@ -415,11 +417,16 @@ if __name__ == "__main__":
         model_dir,
         "".join(["model_ensemble_", args.bin_name, "_E_", str(best_epoch)]),
     )
-    print(f'Best model: {best_model_file}')
+    print(f"Best model: {best_model_file}")
 
     if args.test_data_dir is not None:
         dataset_args["data_dir"] = args.test_data_dir
-        print('Evaluating over test data using best model')
-        test_lxmert_model(imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures, best_ckpt=best_model_file,
-                          dataset_args=dataset_args,
-                          ensemble_args=ensemble_args, optimizer_args=optimizer_args,exp_config=exp_config)
+        print("Evaluating over test data using best model")
+        test_lxmert_model(
+            imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures,
+            best_ckpt=best_model_file,
+            dataset_args=dataset_args,
+            ensemble_args=ensemble_args,
+            optimizer_args=optimizer_args,
+            exp_config=exp_config,
+        )

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -17,6 +17,7 @@ from torch.utils.data import DataLoader
 from lxmert.src.lxrt.optimization import BertAdam
 from models.CNN import ResNet
 from models.LXMERTEnsembleGuesserOnly import LXMERTEnsembleGuesserOnly
+from testing.test_lxmert import test_lxmert_model
 from train.SL.parser import preprocess_config
 from utils.datasets.SL.N2NLXMERTDataset import N2NLXMERTDataset
 from utils.eval import calculate_accuracy
@@ -74,6 +75,7 @@ if __name__ == "__main__":
         help="track experiment using various framework, currently supports W&B: use wandb",
         default=None,
     )
+    parser.add_argument("-test_data_dir", type=str, default=None, help="Test data directory")
 
     args = parser.parse_args()
     print(args.exp_name)
@@ -164,7 +166,6 @@ if __name__ == "__main__":
 
     # Init model
     model = LXMERTEnsembleGuesserOnly(**ensemble_args, from_scratch=args.from_scratch)
-    # TODO Checkpoint loading
 
     if multiple_gpus_available:
         model = DataParallel(model)
@@ -224,9 +225,11 @@ if __name__ == "__main__":
         optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         start_e = checkpoint["epoch"] + 1
         loss = checkpoint["loss"]
+        val_accuracies = checkpoint["val_accuracies"]
     else:
         start_e = 0
         loss = 0
+        val_accuracies = []
 
     for epoch in range(start_e, optimizer_args["no_epochs"]):
         start = time()
@@ -354,7 +357,7 @@ if __name__ == "__main__":
                     val_guesser_loss = torch.cat([val_guesser_loss, guesser_loss.data])
 
                     val_total_loss = torch.cat([val_total_loss, loss.data])
-
+        val_accuracies.append(np.mean(validation_guesser_accuracy))
         if exp_config["save_models"]:
             model_file = os.path.join(
                 model_dir,
@@ -366,6 +369,7 @@ if __name__ == "__main__":
                     "model_state_dict": model.state_dict(),
                     "optimizer_state_dict": optimizer.state_dict(),
                     "loss": loss,
+                    "val_accuracies": val_accuracies,
                 },
                 model_file,
             )
@@ -405,3 +409,17 @@ if __name__ == "__main__":
 
         if exp_config["save_models"]:
             print("Saved model to %s" % (model_file))
+
+    best_epoch = np.argmax(val_accuracies)
+    best_model_file = os.path.join(
+        model_dir,
+        "".join(["model_ensemble_", args.bin_name, "_E_", str(best_epoch)]),
+    )
+    print(f'Best model: {best_model_file}')
+
+    if args.test_data_dir is not None:
+        dataset_args["data_dir"] = args.test_data_dir
+        print('Evaluating over test data using best model')
+        test_lxmert_model(imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures, best_ckpt=best_model_file,
+                          dataset_args=dataset_args,
+                          ensemble_args=ensemble_args, optimizer_args=optimizer_args,exp_config=exp_config)

--- a/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
@@ -268,6 +268,7 @@ if __name__ == "__main__":
                     val_guesser_loss = torch.cat([val_guesser_loss, guesser_loss.data])
                     val_total_loss = torch.cat([val_total_loss, loss.data])
 
+        val_accuracies.append(np.mean(validation_guesser_accuracy))
         if exp_config["save_models"]:
             model_file = os.path.join(
                 model_dir,
@@ -331,4 +332,4 @@ if __name__ == "__main__":
         dataset_args["data_dir"] = args.test_data_dir
         print('Evaluating over test data using best model')
         test_model(model_type='visual', best_ckpt=best_model_file, dataset_args=dataset_args,
-                   ensemble_args=ensemble_args, optimizer_args=optimizer_args)
+                   ensemble_args=ensemble_args, optimizer_args=optimizer_args,exp_config=exp_config)

--- a/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
@@ -71,7 +71,9 @@ if __name__ == "__main__":
         help="track experiment using various framework, currently supports W&B: use wandb",
         default=None,
     )
-    parser.add_argument("-test_data_dir", type=str, default=None, help="Test data directory")
+    parser.add_argument(
+        "-test_data_dir", type=str, default=None, help="Test data directory"
+    )
 
     args = parser.parse_args()
     print(args.exp_name)
@@ -326,10 +328,16 @@ if __name__ == "__main__":
         model_dir,
         "".join(["model_ensemble_", args.bin_name, "_E_", str(best_epoch)]),
     )
-    print(f'Best model: {best_model_file}')
+    print(f"Best model: {best_model_file}")
 
     if args.test_data_dir is not None:
         dataset_args["data_dir"] = args.test_data_dir
-        print('Evaluating over test data using best model')
-        test_model(model_type='visual', best_ckpt=best_model_file, dataset_args=dataset_args,
-                   ensemble_args=ensemble_args, optimizer_args=optimizer_args,exp_config=exp_config)
+        print("Evaluating over test data using best model")
+        test_model(
+            model_type="visual",
+            best_ckpt=best_model_file,
+            dataset_args=dataset_args,
+            ensemble_args=ensemble_args,
+            optimizer_args=optimizer_args,
+            exp_config=exp_config,
+        )


### PR DESCRIPTION
This PR adds code to select best model based on the highest validation accuracy during training. Best model is shown at the end of the training.

It is also capable of selecting the best model if we start training from certain checkpoint because we save validation accuracy to checkpoint dictionary. 

Optionally, best model can be evaluated on test data. A new parameter `test_data_dir` is added which expects path to the directory of the test data files.

Sample command:

```
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=/home/users/bverma/project/sync/dh/model-repos/aixia2021 \
python train/SL/train_lstm_guesser_only.py \
-no_decider \
-exp_name test \
-bin_name test \
-test_data_dir data/test/experiments/task_success
```

`data/test/experiments/task_success` directory should contain all test files like original vocab, n2n test data, test image and object features as well as guesswhat test jsons.

These changes are tested with base lstm and roberta model.