### PR TITLE
create image and object features on the go

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ python src/guesswhat/preprocess_data/extract_img_features.py \
 
 ### Image features for the Aixia2021 repository
 
+**Important: these features will be created on the go as you start the training script.** There is no need to do anything and you can skip this section unless you would like to decouple the image feature creation from the training process. 
+
 The scripts below assume that you are already in the model directory at ```model-repos/aixia2021/```.
 
 Unlike the original repository, the Aixia2021 repository uses ResNet features. To run the models, both the image and object features will need to be generated. 

--- a/model-repos/aixia2021/config/SL/config.json
+++ b/model-repos/aixia2021/config/SL/config.json
@@ -72,7 +72,7 @@
   },
 
   "data_paths": {
-    "image_path":"data/img/raw/",
+    "image_path":"./data/images",
     "train": "guesswhat.train.jsonl.gz",
     "val": "guesswhat.valid.jsonl.gz",
     "test":"guesswhat.test.jsonl.gz",

--- a/model-repos/aixia2021/config/SL/config_bert.json
+++ b/model-repos/aixia2021/config/SL/config_bert.json
@@ -79,7 +79,7 @@
   },
 
   "data_paths": {
-    "image_path":"./data/GuessWhat/",
+    "image_path":"./data/images",
     "train": "guesswhat.train.jsonl.gz",
     "val": "guesswhat.valid.jsonl.gz",
     "test":"guesswhat.test.jsonl.gz",

--- a/model-repos/aixia2021/config/SL/config_devries.json
+++ b/model-repos/aixia2021/config/SL/config_devries.json
@@ -70,7 +70,7 @@
   },
 
   "data_paths": {
-    "image_path":"./data/GuessWhat/",
+    "image_path":"./data/images",
     "train": "guesswhat.train.jsonl.gz",
     "val": "guesswhat.valid.jsonl.gz",
     "test":"guesswhat.test.jsonl.gz",

--- a/model-repos/aixia2021/config/SL/config_devries_bert.json
+++ b/model-repos/aixia2021/config/SL/config_devries_bert.json
@@ -70,7 +70,7 @@
   },
 
   "data_paths": {
-    "image_path":"./data/GuessWhat/",
+    "image_path":"./data/images",
     "train": "guesswhat.train.jsonl.gz",
     "val": "guesswhat.valid.jsonl.gz",
     "test":"guesswhat.test.jsonl.gz",

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -151,6 +151,8 @@ if __name__ == "__main__":
         dataset_val = N2NDataset(
             split="val", **dataset_args, complete_only=True, num_turns=args.num_turns
         )
+        dataset_train.prepare_features(split='train')
+        dataset_val.prepare_features(split='val')
 
     for epoch in range(start_e, optimizer_args["no_epochs"]):
         start = time()

--- a/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lstm_guesser_only.py
@@ -151,8 +151,8 @@ if __name__ == "__main__":
         dataset_val = N2NDataset(
             split="val", **dataset_args, complete_only=True, num_turns=args.num_turns
         )
-        dataset_train.prepare_features(split='train')
-        dataset_val.prepare_features(split='val')
+        dataset_train.prepare_features(split="train")
+        dataset_val.prepare_features(split="val")
 
     for epoch in range(start_e, optimizer_args["no_epochs"]):
         start = time()

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -208,8 +208,8 @@ if __name__ == "__main__":
             imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures,
             num_turns=args.num_turns,
         )
-        dataset_train.prepare_features(split='train')
-        dataset_val.prepare_features(split='val')
+        dataset_train.prepare_features(split="train")
+        dataset_val.prepare_features(split="val")
 
     print("Initializing the optimizer...")
     num_batches_per_epoch = len(dataset_train) // optimizer_args["batch_size"]

--- a/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_lxmert_guesser_only.py
@@ -208,6 +208,8 @@ if __name__ == "__main__":
             imgid2fasterRCNNfeatures=imgid2fasterRCNNfeatures,
             num_turns=args.num_turns,
         )
+        dataset_train.prepare_features(split='train')
+        dataset_val.prepare_features(split='val')
 
     print("Initializing the optimizer...")
     num_batches_per_epoch = len(dataset_train) // optimizer_args["batch_size"]

--- a/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
@@ -151,6 +151,8 @@ if __name__ == "__main__":
         dataset_val = N2NDataset(
             split="val", **dataset_args, complete_only=True, num_turns=args.num_turns
         )
+        dataset_train.prepare_features(split='train')
+        dataset_val.prepare_features(split='val')
 
     for epoch in range(start_e, optimizer_args["no_epochs"]):
         start = time()

--- a/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
+++ b/model-repos/aixia2021/train/SL/train_vlstm_guesser_only.py
@@ -151,8 +151,8 @@ if __name__ == "__main__":
         dataset_val = N2NDataset(
             split="val", **dataset_args, complete_only=True, num_turns=args.num_turns
         )
-        dataset_train.prepare_features(split='train')
-        dataset_val.prepare_features(split='val')
+        dataset_train.prepare_features(split="train")
+        dataset_val.prepare_features(split="val")
 
     for epoch in range(start_e, optimizer_args["no_epochs"]):
         start = time()

--- a/model-repos/aixia2021/utils/ExtractImgfeatures.py
+++ b/model-repos/aixia2021/utils/ExtractImgfeatures.py
@@ -29,7 +29,7 @@ def extract_features(img_dir, model, img_list, my_cpu=False):
         avg_img_features = np.zeros((len(img_list), 2048))
 
     name2id = dict()
-    print("creating features ....")
+    print("extracting features ....")
     for i in range(len(img_list)):
         if i >= 5 and my_cpu:
             break
@@ -40,6 +40,7 @@ def extract_features(img_dir, model, img_list, my_cpu=False):
         conv_features, feat = model(ImgTensor)
         avg_img_features[i] = feat.cpu().data.numpy()
         name2id[img_list[i]] = i
+    print("Done.")
 
     return avg_img_features, name2id
 
@@ -51,18 +52,17 @@ def get_image_data(n2n_file):
         data.append(v["image_file"])
     return data
 
-def create_image_features(image_dir, n2n_train_set, n2n_val_set, n2n_test_set, image_features_json_path, image_features_path):
+def create_image_features(image_dir, n2n_train_set, n2n_val_set, image_features_json_path, image_features_path):
     start = time()
-    print("Start")
-    splits = ["train", "val", "test"]
+    print("Creating new ResNet features")
+    splits = ["train", "val"]
 
     my_cpu = False
 
-    images = {"train": [], "val": [], "test": []}
+    images = {"train": [], "val": []}
 
     images['train'] = get_image_data(n2n_train_set)
     images['val'] = get_image_data(n2n_val_set)
-    images['test'] = get_image_data(n2n_test_set)
 
     model = ResNet()
     model = model.eval()
@@ -102,9 +102,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-n2n_val_set", type=str, default="data/n2n_val_successful_data.json"
-    )
-    parser.add_argument(
-        "-n2n_test_set", type=str, default="data/n2n_test_successful_data.json"
     )
     parser.add_argument(
         "-image_features_json_path",

--- a/model-repos/aixia2021/utils/ExtractImgfeatures.py
+++ b/model-repos/aixia2021/utils/ExtractImgfeatures.py
@@ -44,6 +44,7 @@ def extract_features(img_dir, model, img_list, my_cpu=False):
 
     return avg_img_features, name2id
 
+
 def get_image_data(n2n_file):
     data = []
     with open(n2n_file, "r") as file_v:
@@ -52,7 +53,10 @@ def get_image_data(n2n_file):
         data.append(v["image_file"])
     return data
 
-def create_image_features(image_dir, n2n_train_set, n2n_val_set, image_features_json_path, image_features_path):
+
+def create_image_features(
+    image_dir, n2n_train_set, n2n_val_set, image_features_json_path, image_features_path
+):
     start = time()
     print("Creating new ResNet features")
     splits = ["train", "val"]
@@ -61,8 +65,8 @@ def create_image_features(image_dir, n2n_train_set, n2n_val_set, image_features_
 
     images = {"train": [], "val": []}
 
-    images['train'] = get_image_data(n2n_train_set)
-    images['val'] = get_image_data(n2n_val_set)
+    images["train"] = get_image_data(n2n_train_set)
+    images["val"] = get_image_data(n2n_val_set)
 
     model = ResNet()
     model = model.eval()

--- a/model-repos/aixia2021/utils/datasets/SL/N2NBERTDataset.py
+++ b/model-repos/aixia2021/utils/datasets/SL/N2NBERTDataset.py
@@ -36,13 +36,22 @@ class N2NBERTDataset(Dataset):
                 self.data_args["data_dir"],
                 self.data_args["data_paths"]["ResNet"]["objects_features_index"],
             )
-            if not (os.path.isfile(objects_feat_file) and os.path.isfile(objects_feat_mapping_file)):
-                create_object_features(image_dir=self.data_args["data_paths"]["image_path"],
-                                      training_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['train']),
-                                      validation_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['val']),
-                                      objects_features_path=objects_feat_file,
-                                      objects_features_index_path=objects_feat_mapping_file,
-                                      )
+            if not (
+                os.path.isfile(objects_feat_file)
+                and os.path.isfile(objects_feat_mapping_file)
+            ):
+                create_object_features(
+                    image_dir=self.data_args["data_paths"]["image_path"],
+                    training_set=os.path.join(
+                        self.data_args["data_dir"],
+                        self.data_args["data_paths"]["train"],
+                    ),
+                    validation_set=os.path.join(
+                        self.data_args["data_dir"], self.data_args["data_paths"]["val"]
+                    ),
+                    objects_features_path=objects_feat_file,
+                    objects_features_index_path=objects_feat_mapping_file,
+                )
             self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
 
             with open(objects_feat_mapping_file, "r") as file_v:

--- a/model-repos/aixia2021/utils/datasets/SL/N2NBERTDataset.py
+++ b/model-repos/aixia2021/utils/datasets/SL/N2NBERTDataset.py
@@ -8,6 +8,7 @@ import numpy as np
 from torch.utils.data import Dataset
 
 from utils.datasets.SL.prepro_lxmert import create_data_file
+from utils.extract_object_features import create_object_features
 
 
 class N2NBERTDataset(Dataset):
@@ -35,6 +36,13 @@ class N2NBERTDataset(Dataset):
                 self.data_args["data_dir"],
                 self.data_args["data_paths"]["ResNet"]["objects_features_index"],
             )
+            if not (os.path.isfile(objects_feat_file) and os.path.isfile(objects_feat_mapping_file)):
+                create_object_features(image_dir=self.data_args["data_paths"]["image_path"],
+                                      training_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['train']),
+                                      validation_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['val']),
+                                      objects_features_path=objects_feat_file,
+                                      objects_features_index_path=objects_feat_mapping_file,
+                                      )
             self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
 
             with open(objects_feat_mapping_file, "r") as file_v:

--- a/model-repos/aixia2021/utils/datasets/SL/N2NDataset.py
+++ b/model-repos/aixia2021/utils/datasets/SL/N2NDataset.py
@@ -14,6 +14,7 @@ from utils.extract_object_features import create_object_features
 
 logger = logging.getLogger(__name__)
 
+
 class N2NDataset(Dataset):
     def __init__(
         self,
@@ -23,7 +24,7 @@ class N2NDataset(Dataset):
         with_objects_feat=False,
         complete_only=False,
         random_image=False,
-        **kwargs
+        **kwargs,
     ):
         self.data_args = kwargs
         self.random_image = random_image
@@ -112,16 +113,20 @@ class N2NDataset(Dataset):
         visual_feat_mapping_file = os.path.join(
             self.data_args["data_dir"], self.data_args["data_paths"]["ResNet"]["img2id"]
         )
-        if not (os.path.isfile(visual_feat_file) and os.path.isfile(visual_feat_mapping_file)):
+        if not (
+            os.path.isfile(visual_feat_file)
+            and os.path.isfile(visual_feat_mapping_file)
+        ):
             logger.info(f"ResNet image features not found.")
             n2n_train_file = "n2n_train_successful_data.json"
             n2n_val_file = "n2n_val_successful_data.json"
-            create_image_features(image_dir=self.data_args["data_paths"]["image_path"],
-                                  n2n_train_set=os.path.join(self.data_args["data_dir"], n2n_train_file),
-                                  n2n_val_set=os.path.join(self.data_args["data_dir"], n2n_val_file),
-                                  image_features_path=visual_feat_file,
-                                  image_features_json_path=visual_feat_mapping_file,
-                                  )
+            create_image_features(
+                image_dir=self.data_args["data_paths"]["image_path"],
+                n2n_train_set=os.path.join(self.data_args["data_dir"], n2n_train_file),
+                n2n_val_set=os.path.join(self.data_args["data_dir"], n2n_val_file),
+                image_features_path=visual_feat_file,
+                image_features_json_path=visual_feat_mapping_file,
+            )
 
         self.vf = np.asarray(h5py.File(visual_feat_file, "r")[split + "_img_features"])
 
@@ -137,14 +142,23 @@ class N2NDataset(Dataset):
                 self.data_args["data_dir"],
                 self.data_args["data_paths"]["ResNet"]["objects_features_index"],
             )
-            if not (os.path.isfile(objects_feat_file) and os.path.isfile(objects_feat_mapping_file)):
+            if not (
+                os.path.isfile(objects_feat_file)
+                and os.path.isfile(objects_feat_mapping_file)
+            ):
                 logger.info(f"ResNet object features not found.")
-                create_object_features(image_dir=self.data_args["data_paths"]["image_path"],
-                                      training_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['train']),
-                                      validation_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['val']),
-                                      objects_features_path=objects_feat_file,
-                                      objects_features_index_path=objects_feat_mapping_file,
-                                      )
+                create_object_features(
+                    image_dir=self.data_args["data_paths"]["image_path"],
+                    training_set=os.path.join(
+                        self.data_args["data_dir"],
+                        self.data_args["data_paths"]["train"],
+                    ),
+                    validation_set=os.path.join(
+                        self.data_args["data_dir"], self.data_args["data_paths"]["val"]
+                    ),
+                    objects_features_path=objects_feat_file,
+                    objects_features_index_path=objects_feat_mapping_file,
+                )
             self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
 
             with open(objects_feat_mapping_file, "r") as file_v:

--- a/model-repos/aixia2021/utils/datasets/SL/N2NDataset.py
+++ b/model-repos/aixia2021/utils/datasets/SL/N2NDataset.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import random
 
@@ -6,9 +7,12 @@ import h5py
 import numpy as np
 from torch.utils.data import Dataset
 
+from utils.ExtractImgfeatures import create_image_features
 from utils.create_subset import create_subset
 from utils.datasets.SL.prepro import create_data_file
+from utils.extract_object_features import create_object_features
 
+logger = logging.getLogger(__name__)
 
 class N2NDataset(Dataset):
     def __init__(
@@ -25,32 +29,6 @@ class N2NDataset(Dataset):
         self.random_image = random_image
         self.with_objects_feat = with_objects_feat
 
-        visual_feat_file = os.path.join(
-            self.data_args["data_dir"],
-            self.data_args["data_paths"]["ResNet"]["image_features"],
-        )
-        visual_feat_mapping_file = os.path.join(
-            self.data_args["data_dir"], self.data_args["data_paths"]["ResNet"]["img2id"]
-        )
-        self.vf = np.asarray(h5py.File(visual_feat_file, "r")[split + "_img_features"])
-
-        with open(visual_feat_mapping_file, "r") as file_v:
-            self.vf_mapping = json.load(file_v)[split + "2id"]
-
-        if with_objects_feat:
-            objects_feat_file = os.path.join(
-                self.data_args["data_dir"],
-                self.data_args["data_paths"]["ResNet"]["objects_features"],
-            )
-            objects_feat_mapping_file = os.path.join(
-                self.data_args["data_dir"],
-                self.data_args["data_paths"]["ResNet"]["objects_features_index"],
-            )
-            self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
-
-            with open(objects_feat_mapping_file, "r") as file_v:
-                self.objects_feat_mapping = json.load(file_v)
-
         tmp_key = split + "_process_file"
 
         if tmp_key in self.data_args["data_paths"]:
@@ -64,6 +42,7 @@ class N2NDataset(Dataset):
         if self.data_args["new_data"] or not os.path.isfile(
             os.path.join(self.data_args["data_dir"], data_file_name)
         ):
+            logger.info(f"N2N data file not found for {split}.")
             create_data_file(
                 data_dir=self.data_args["data_dir"],
                 data_file=self.data_args["data_paths"][split],
@@ -124,6 +103,52 @@ class N2NDataset(Dataset):
                     filtered_n2n_data[str(_id)] = v
                     _id += 1
             self.n2n_data = filtered_n2n_data
+
+    def prepare_features(self, split):
+        visual_feat_file = os.path.join(
+            self.data_args["data_dir"],
+            self.data_args["data_paths"]["ResNet"]["image_features"],
+        )
+        visual_feat_mapping_file = os.path.join(
+            self.data_args["data_dir"], self.data_args["data_paths"]["ResNet"]["img2id"]
+        )
+        if not (os.path.isfile(visual_feat_file) and os.path.isfile(visual_feat_mapping_file)):
+            logger.info(f"ResNet image features not found.")
+            n2n_train_file = "n2n_train_successful_data.json"
+            n2n_val_file = "n2n_val_successful_data.json"
+            create_image_features(image_dir=self.data_args["data_paths"]["image_path"],
+                                  n2n_train_set=os.path.join(self.data_args["data_dir"], n2n_train_file),
+                                  n2n_val_set=os.path.join(self.data_args["data_dir"], n2n_val_file),
+                                  image_features_path=visual_feat_file,
+                                  image_features_json_path=visual_feat_mapping_file,
+                                  )
+
+        self.vf = np.asarray(h5py.File(visual_feat_file, "r")[split + "_img_features"])
+
+        with open(visual_feat_mapping_file, "r") as file_v:
+            self.vf_mapping = json.load(file_v)[split + "2id"]
+
+        if self.with_objects_feat:
+            objects_feat_file = os.path.join(
+                self.data_args["data_dir"],
+                self.data_args["data_paths"]["ResNet"]["objects_features"],
+            )
+            objects_feat_mapping_file = os.path.join(
+                self.data_args["data_dir"],
+                self.data_args["data_paths"]["ResNet"]["objects_features_index"],
+            )
+            if not (os.path.isfile(objects_feat_file) and os.path.isfile(objects_feat_mapping_file)):
+                logger.info(f"ResNet object features not found.")
+                create_object_features(image_dir=self.data_args["data_paths"]["image_path"],
+                                      training_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['train']),
+                                      validation_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['val']),
+                                      objects_features_path=objects_feat_file,
+                                      objects_features_index_path=objects_feat_mapping_file,
+                                      )
+            self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
+
+            with open(objects_feat_mapping_file, "r") as file_v:
+                self.objects_feat_mapping = json.load(file_v)
 
     def __len__(self):
         return len(self.n2n_data)

--- a/model-repos/aixia2021/utils/datasets/SL/N2NLXMERTDataset.py
+++ b/model-repos/aixia2021/utils/datasets/SL/N2NLXMERTDataset.py
@@ -226,15 +226,19 @@ class N2NLXMERTDataset(Dataset):
         visual_feat_mapping_file = os.path.join(
             self.data_args["data_dir"], self.data_args["data_paths"]["ResNet"]["img2id"]
         )
-        if not (os.path.isfile(visual_feat_file) and os.path.isfile(visual_feat_mapping_file)):
+        if not (
+            os.path.isfile(visual_feat_file)
+            and os.path.isfile(visual_feat_mapping_file)
+        ):
             n2n_train_file = "n2n_train_successful_data.json"
             n2n_val_file = "n2n_val_successful_data.json"
-            create_image_features(image_dir=self.data_args["data_paths"]["image_path"],
-                                  n2n_train_set=os.path.join(self.data_args["data_dir"], n2n_train_file),
-                                  n2n_val_set=os.path.join(self.data_args["data_dir"], n2n_val_file),
-                                  image_features_path=visual_feat_file,
-                                  image_features_json_path=visual_feat_mapping_file,
-                                  )
+            create_image_features(
+                image_dir=self.data_args["data_paths"]["image_path"],
+                n2n_train_set=os.path.join(self.data_args["data_dir"], n2n_train_file),
+                n2n_val_set=os.path.join(self.data_args["data_dir"], n2n_val_file),
+                image_features_path=visual_feat_file,
+                image_features_json_path=visual_feat_mapping_file,
+            )
 
         self.vf = np.asarray(h5py.File(visual_feat_file, "r")[split + "_img_features"])
 
@@ -250,18 +254,26 @@ class N2NLXMERTDataset(Dataset):
                 self.data_args["data_dir"],
                 self.data_args["data_paths"]["ResNet"]["objects_features_index"],
             )
-            if not (os.path.isfile(objects_feat_file) and os.path.isfile(objects_feat_mapping_file)):
-                create_object_features(image_dir=self.data_args["data_paths"]["image_path"],
-                                      training_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['train']),
-                                      validation_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['val']),
-                                      objects_features_path=objects_feat_file,
-                                      objects_features_index_path=objects_feat_mapping_file,
-                                      )
+            if not (
+                os.path.isfile(objects_feat_file)
+                and os.path.isfile(objects_feat_mapping_file)
+            ):
+                create_object_features(
+                    image_dir=self.data_args["data_paths"]["image_path"],
+                    training_set=os.path.join(
+                        self.data_args["data_dir"],
+                        self.data_args["data_paths"]["train"],
+                    ),
+                    validation_set=os.path.join(
+                        self.data_args["data_dir"], self.data_args["data_paths"]["val"]
+                    ),
+                    objects_features_path=objects_feat_file,
+                    objects_features_index_path=objects_feat_mapping_file,
+                )
             self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
 
             with open(objects_feat_mapping_file, "r") as file_v:
                 self.objects_feat_mapping = json.load(file_v)
-
 
     def __len__(self):
         return len(self.n2n_data)

--- a/model-repos/aixia2021/utils/datasets/SL/N2NLXMERTDataset.py
+++ b/model-repos/aixia2021/utils/datasets/SL/N2NLXMERTDataset.py
@@ -7,7 +7,9 @@ import h5py
 import numpy as np
 from torch.utils.data import Dataset
 
+from utils.ExtractImgfeatures import create_image_features
 from utils.datasets.SL.prepro_lxmert import create_data_file
+from utils.extract_object_features import create_object_features
 
 
 class N2NLXMERTDataset(Dataset):
@@ -30,31 +32,6 @@ class N2NLXMERTDataset(Dataset):
 
         if random_image:
             print("Using random images...")
-
-        visual_feat_file = os.path.join(
-            self.data_args["data_dir"],
-            self.data_args["data_paths"]["ResNet"]["image_features"],
-        )
-        visual_feat_mapping_file = os.path.join(
-            self.data_args["data_dir"], self.data_args["data_paths"]["ResNet"]["img2id"]
-        )
-        self.vf = np.asarray(h5py.File(visual_feat_file, "r")[split + "_img_features"])
-        with open(visual_feat_mapping_file, "r") as file_v:
-            self.vf_mapping = json.load(file_v)[split + "2id"]
-
-        if with_objects_feat:
-            objects_feat_file = os.path.join(
-                self.data_args["data_dir"],
-                self.data_args["data_paths"]["ResNet"]["objects_features"],
-            )
-            objects_feat_mapping_file = os.path.join(
-                self.data_args["data_dir"],
-                self.data_args["data_paths"]["ResNet"]["objects_features_index"],
-            )
-            self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
-
-            with open(objects_feat_mapping_file, "r") as file_v:
-                self.objects_feat_mapping = json.load(file_v)
 
         tmp_key = split + "_process_file"
 
@@ -240,6 +217,51 @@ class N2NLXMERTDataset(Dataset):
             self.n2n_data[k]["FasterRCNN"] = self.data_args["imgid2fasterRCNNfeatures"][
                 self.n2n_data[k]["image_file"].split(".")[0]
             ]
+
+    def prepare_features(self, split):
+        visual_feat_file = os.path.join(
+            self.data_args["data_dir"],
+            self.data_args["data_paths"]["ResNet"]["image_features"],
+        )
+        visual_feat_mapping_file = os.path.join(
+            self.data_args["data_dir"], self.data_args["data_paths"]["ResNet"]["img2id"]
+        )
+        if not (os.path.isfile(visual_feat_file) and os.path.isfile(visual_feat_mapping_file)):
+            n2n_train_file = "n2n_train_successful_data.json"
+            n2n_val_file = "n2n_val_successful_data.json"
+            create_image_features(image_dir=self.data_args["data_paths"]["image_path"],
+                                  n2n_train_set=os.path.join(self.data_args["data_dir"], n2n_train_file),
+                                  n2n_val_set=os.path.join(self.data_args["data_dir"], n2n_val_file),
+                                  image_features_path=visual_feat_file,
+                                  image_features_json_path=visual_feat_mapping_file,
+                                  )
+
+        self.vf = np.asarray(h5py.File(visual_feat_file, "r")[split + "_img_features"])
+
+        with open(visual_feat_mapping_file, "r") as file_v:
+            self.vf_mapping = json.load(file_v)[split + "2id"]
+
+        if self.with_objects_feat:
+            objects_feat_file = os.path.join(
+                self.data_args["data_dir"],
+                self.data_args["data_paths"]["ResNet"]["objects_features"],
+            )
+            objects_feat_mapping_file = os.path.join(
+                self.data_args["data_dir"],
+                self.data_args["data_paths"]["ResNet"]["objects_features_index"],
+            )
+            if not (os.path.isfile(objects_feat_file) and os.path.isfile(objects_feat_mapping_file)):
+                create_object_features(image_dir=self.data_args["data_paths"]["image_path"],
+                                      training_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['train']),
+                                      validation_set=os.path.join(self.data_args["data_dir"], self.data_args["data_paths"]['val']),
+                                      objects_features_path=objects_feat_file,
+                                      objects_features_index_path=objects_feat_mapping_file,
+                                      )
+            self.objects_vf = h5py.File(objects_feat_file, "r")["objects_features"]
+
+            with open(objects_feat_mapping_file, "r") as file_v:
+                self.objects_feat_mapping = json.load(file_v)
+
 
     def __len__(self):
         return len(self.n2n_data)

--- a/model-repos/aixia2021/utils/extract_object_features.py
+++ b/model-repos/aixia2021/utils/extract_object_features.py
@@ -10,9 +10,16 @@ from torchvision import transforms
 
 from models.CNN import ResNet
 
-def create_object_features(image_dir, training_set, validation_set, objects_features_index_path, objects_features_path):
+
+def create_object_features(
+    image_dir,
+    training_set,
+    validation_set,
+    objects_features_index_path,
+    objects_features_path,
+):
     games = []
-    print('Creating object features .....')
+    print("Creating object features .....")
     print("Loading file: {}".format(training_set))
     with gzip.open(training_set) as file:
         for json_game in file:


### PR DESCRIPTION
~Previously, we created one feature file for train+val and then separately for test split. With these changes, only one ResNet image feature file will be created for all splits. It requires n2n data files for all splits.~

This PR modularize `model-repos/aixia2021/utils/ExtractImgfeatures.py` and `model-repos/aixia2021/utils/extract_object_features.py` so that image and feature extraction can be done independently without using these scripts directly. 
This allows us to create image and object features during the training cycle without having to create it separately before training. However, it is to be noted that this would significantly increase training time as creation of these features takes few hours.

Overall functionality remains same. `ExtractImgfeatures` uses train and val _n2n data files_ to create one `ResNet_avg_image_features.h5` file which contains images features for both splits. Mapping from split to respective image features is done using `ResNet_avg_image_features2id.json`. Similarly, `extract_object_features` creates object features by combining the games from train and val _guesswhat json files_ to create one `objects_features_test.h5`. In this case, there is no mapping based on split rather using game_id which is done by `objects_features_index_test.json`.
**Note**: Object features will only be created or used if `with_objects_feat` parameter to N2NDataset class is `True`, by default this parameter is `False`.